### PR TITLE
Don't apply if getTyped() throws

### DIFF
--- a/Provider/src/main/java/dev/openfeature/contrib/providers/ConfidenceFeatureProvider.kt
+++ b/Provider/src/main/java/dev/openfeature/contrib/providers/ConfidenceFeatureProvider.kt
@@ -130,9 +130,10 @@ class ConfidenceFeatureProvider private constructor(
                     ResolveReason.RESOLVE_REASON_MATCH -> {
                         val resolvedValue: Value = findValueFromValuePath(resolvedFlag.value, parsedKey.valuePath)
                             ?: throw ParseError("Unable to parse flag value: ${parsedKey.valuePath.joinToString(separator = "/")}")
+                        val value = getTyped<T>(resolvedValue) ?: defaultValue
                         processApplyAsync(parsedKey.flagName, resolvedFlag.resolveToken)
                         ProviderEvaluation(
-                            value = getTyped<T>(resolvedValue) ?: defaultValue,
+                            value = value,
                             variant = resolvedFlag.variant,
                             reason = Reason.TARGETING_MATCH.toString())
                     }


### PR DESCRIPTION
Being extra safe in getting the final value first, and only send "apply" if the entire evaluation completes correctly 