### PR TITLE
Refactor file write lock during applier init

### DIFF
--- a/Provider/src/main/java/dev/openfeature/contrib/providers/ConfidenceFeatureProvider.kt
+++ b/Provider/src/main/java/dev/openfeature/contrib/providers/ConfidenceFeatureProvider.kt
@@ -81,7 +81,7 @@ class ConfidenceFeatureProvider private constructor(
                 configuredClient,
                 FlagApplierWithRetries(
                     configuredClient,
-                    Dispatchers.IO,
+                    dispatcher,
                     context
                 )
             )

--- a/Provider/src/main/java/dev/openfeature/contrib/providers/apply/FlagApplierWithRetries.kt
+++ b/Provider/src/main/java/dev/openfeature/contrib/providers/apply/FlagApplierWithRetries.kt
@@ -9,10 +9,8 @@ import dev.openfeature.contrib.providers.client.InstantTypeAdapter
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.selects.select
 import java.io.File
 import java.time.Instant
 import java.util.*
@@ -49,12 +47,7 @@ class FlagApplierWithRetries(
             val data: FlagsAppliedMap = mutableMapOf()
             readFile(data)
 
-            // the select clause ensures only one at the time
-            // of this events can come true,
-            // either the write request or trigger signal,
-            // makes sure we get them one by one and fairly distributed
-            // the thread will suspended until we are done
-            for(writeRequest in writeRequestChannel) {
+            for (writeRequest in writeRequestChannel) {
                 internalApply(writeRequest.flagName, writeRequest.resolveToken, data)
             }
         }

--- a/Provider/src/test/java/dev/openfeature/contrib/providers/ConfidenceFeatureProviderTests.kt
+++ b/Provider/src/test/java/dev/openfeature/contrib/providers/ConfidenceFeatureProviderTests.kt
@@ -11,7 +11,6 @@ package dev.openfeature.contrib.providers
 
 import android.content.Context
 import dev.openfeature.contrib.providers.apply.APPLY_FILE_NAME
-import dev.openfeature.contrib.providers.apply.FlagApplierWithRetries
 import dev.openfeature.contrib.providers.cache.InMemoryCache
 import dev.openfeature.contrib.providers.client.ConfidenceClient
 import dev.openfeature.contrib.providers.client.ResolveFlagsResponse
@@ -96,7 +95,6 @@ internal class ConfidenceFeatureProviderTests {
     @Test
     fun testMatching() = runTest {
         val testDispatcher = UnconfinedTestDispatcher(testScheduler)
-        val flagApplier = FlagApplierWithRetries(mockClient, testDispatcher, mockContext)
         val confidenceFeatureProvider = ConfidenceFeatureProvider.Builder(mockContext, "")
             .cache(InMemoryCache())
             .client(mockClient)
@@ -168,7 +166,6 @@ internal class ConfidenceFeatureProviderTests {
     @Test
     fun testDelayedApply() = runTest {
         val testDispatcher = UnconfinedTestDispatcher(testScheduler)
-        val flagApplier = FlagApplierWithRetries(mockClient, testDispatcher, mockContext)
         val confidenceFeatureProvider = ConfidenceFeatureProvider.Builder(mockContext, "")
             .cache(InMemoryCache())
             .client(mockClient)
@@ -297,7 +294,6 @@ internal class ConfidenceFeatureProviderTests {
                 "}"
         )
         val testDispatcher = UnconfinedTestDispatcher(testScheduler)
-        val flagApplier = FlagApplierWithRetries(mockClient, testDispatcher, mockContext)
         val confidenceFeatureProvider = ConfidenceFeatureProvider.Builder(mockContext, "")
             .cache(InMemoryCache())
             .client(mockClient)
@@ -314,7 +310,6 @@ internal class ConfidenceFeatureProviderTests {
 
         verify(mockClient, times(1)).resolve(any(), eq(evaluationContext))
 
-        // Evaluate a flag property in order to trigger an apply
         confidenceFeatureProvider.getStringEvaluation("fdema-kotlin-flag-1.mystring", "empty", evaluationContext)
         advanceUntilIdle()
         verify(mockClient, times(1)).apply(any(), eq("token1"))


### PR DESCRIPTION
Mostly familiarizing with Coroutines, no major benefit with this approach. Perhaps nice to have read/write methods explicitly `suspend` and that `readFile()` doesn't need to internally manage the `isLoadingFileData` boolean, which is now only set in the `init` method.