### PR TITLE
Use select expression to not share the mutable data and file

### DIFF
--- a/Provider/src/main/java/dev/openfeature/contrib/providers/apply/FlagApplierWithRetries.kt
+++ b/Provider/src/main/java/dev/openfeature/contrib/providers/apply/FlagApplierWithRetries.kt
@@ -56,7 +56,7 @@ class FlagApplierWithRetries(
         .create()
 
     private val exceptionHandler by lazy {
-        CoroutineExceptionHandler { _, throwable -> println(throwable.message) }
+        CoroutineExceptionHandler { _, _ -> }
     }
 
     init {


### PR DESCRIPTION
in order to avoid sharing writing to the file operation between different coroutines, we can use the select expression to make sure only one event is being handled at any certain time.