### PR TITLE
One apply per flag+resolveToken

### DIFF
--- a/Provider/src/test/java/dev/openfeature/contrib/providers/ConfidenceFeatureProviderTests.kt
+++ b/Provider/src/test/java/dev/openfeature/contrib/providers/ConfidenceFeatureProviderTests.kt
@@ -242,7 +242,7 @@ internal class ConfidenceFeatureProviderTests {
         assertEquals(1, captor.firstValue.count())
         assertEquals("fdema-kotlin-flag-1", captor.firstValue.first().flag)
 
-        assertEquals(true, Json.parseToJsonElement(cacheFile.readText()).jsonObject["token1"]?.jsonObject?.get("fdema-kotlin-flag-1")?.jsonObject?.get("sent")?.jsonPrimitive?.boolean)
+        assertEquals(0, Json.parseToJsonElement(cacheFile.readText()).jsonObject.size)
         assertEquals("red", evalString.value)
         assertEquals(false, evalBool.value)
         assertEquals(7, evalInteger.value)
@@ -323,7 +323,7 @@ internal class ConfidenceFeatureProviderTests {
 
         advanceUntilIdle()
         verify(mockClient, times(1)).apply(any(), eq("token1"))
-        assertEquals(true, Json.parseToJsonElement(cacheFile.readText()).jsonObject["token1"]?.jsonObject?.get("fdema-kotlin-flag-1")?.jsonObject?.get("sent")?.jsonPrimitive?.boolean)
+        assertEquals(0, Json.parseToJsonElement(cacheFile.readText()).jsonObject.size)
 
         val captor1 = argumentCaptor<List<AppliedFlag>>()
         verify(mockClient, times(1)).apply(captor1.capture(), eq("token1"))
@@ -351,10 +351,7 @@ internal class ConfidenceFeatureProviderTests {
 
         advanceUntilIdle()
         verify(mockClient, times(1)).apply(any(), eq("token2"))
-
-        assertEquals(true, Json.parseToJsonElement(cacheFile.readText()).jsonObject["token1"]?.jsonObject?.get("fdema-kotlin-flag-1")?.jsonObject?.get("sent")?.jsonPrimitive?.boolean)
-        assertEquals(true, Json.parseToJsonElement(cacheFile.readText()).jsonObject["token2"]?.jsonObject?.get("fdema-kotlin-flag-1")?.jsonObject?.get("sent")?.jsonPrimitive?.boolean)
-
+        assertEquals(0, Json.parseToJsonElement(cacheFile.readText()).jsonObject.size)
         val captor = argumentCaptor<List<AppliedFlag>>()
         verify(mockClient, times(1)).apply(captor.capture(), eq("token2"))
 
@@ -449,13 +446,10 @@ internal class ConfidenceFeatureProviderTests {
         )
 
         advanceUntilIdle()
-        assertEquals(2, Json.parseToJsonElement(cacheFile.readText()).jsonObject.size)
-        assertEquals(3, Json.parseToJsonElement(cacheFile.readText()).jsonObject["token2"]?.jsonObject?.size)
-        assertEquals(true, Json.parseToJsonElement(cacheFile.readText()).jsonObject["token2"]?.jsonObject?.get("fdema-kotlin-flag-1")?.jsonObject?.get("sent")?.jsonPrimitive?.boolean)
-        assertEquals(true, Json.parseToJsonElement(cacheFile.readText()).jsonObject["token2"]?.jsonObject?.get("fdema-kotlin-flag-2")?.jsonObject?.get("sent")?.jsonPrimitive?.boolean)
-        assertEquals(true, Json.parseToJsonElement(cacheFile.readText()).jsonObject["token2"]?.jsonObject?.get("fdema-kotlin-flag-3")?.jsonObject?.get("sent")?.jsonPrimitive?.boolean)
-        assertEquals(1, Json.parseToJsonElement(cacheFile.readText()).jsonObject["token3"]?.jsonObject?.size)
-        assertEquals(true, Json.parseToJsonElement(cacheFile.readText()).jsonObject["token3"]?.jsonObject?.get("fdema-kotlin-flag-4")?.jsonObject?.get("sent")?.jsonPrimitive?.boolean)
+        verify(mockClient, times(0)).apply(any(), eq("token1"))
+        verify(mockClient, times(1)).apply(any(), eq("token2"))
+        verify(mockClient, times(1)).apply(any(), eq("token3"))
+        assertEquals(0, Json.parseToJsonElement(cacheFile.readText()).jsonObject.size)
     }
 
     @Test


### PR DESCRIPTION
Requirement is to send `apply` once, when a flag is evaluated by the hosting app (no matter which flag's inner value is specifically read). As long as the `resolveToken` doesn't change (i.e. the cached data is not refreshed), no second `apply` event is needed for a flag that is evaluated multiple times.

The in-memory cache will keep track of the flag+resolveToken that have been sent (to avoid duplicated sends), but the file will only keep track of the apply instances that have NOT been sent; the reason for this is that we don't want an ever growing file tracking every apply event ever send by the App. However, this also introduce some limitations: it's possible that the same `resolveToken` is used between sessions: in this case, if all events are sent on the first session and the file is empty, new apply events will be sent on the second session; sending multiple apply events for the same flag+resolveToken is not a problem per-se, and this is only a best-effort way to limit double sending. Moreover, in most scenarios, the cache is refreshed on a new app's session (meaning new resolveToken, and indeed the need to send new `apply` events again).