### PR TITLE
Use flag in `konfidens-e2e` for IT tests

### DIFF
--- a/Provider/src/test/java/dev/openfeature/contrib/providers/ConfidenceIntegrationTests.kt
+++ b/Provider/src/test/java/dev/openfeature/contrib/providers/ConfidenceIntegrationTests.kt
@@ -6,6 +6,7 @@ import dev.openfeature.contrib.providers.cache.InMemoryCache
 import dev.openfeature.sdk.MutableContext
 import dev.openfeature.sdk.OpenFeatureAPI
 import dev.openfeature.sdk.Reason
+import dev.openfeature.sdk.Value
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -19,7 +20,7 @@ import java.io.File
 import java.nio.file.Files
 import java.util.UUID
 
-private const val clientSecret = "YZ2x7AClM1Rynl8HFfEZtNTSIWdWsNUS"
+private const val clientSecret = "ldZWlt6ywPIiPNf16WINSTh0yoHzSQEc"
 private val mockContext: Context = mock()
 
 class ConfidenceIntegrationTests {
@@ -35,16 +36,25 @@ class ConfidenceIntegrationTests {
                 ConfidenceFeatureProvider.Builder(mockContext, clientSecret)
                     .cache(InMemoryCache())
                     .build(),
-                MutableContext(targetingKey = UUID.randomUUID().toString())
+                MutableContext(
+                    targetingKey = UUID.randomUUID().toString(),
+                    attributes = mutableMapOf(
+                        "user" to Value.Structure(
+                            mapOf(
+                                "country" to Value.String("SE")
+                            )
+                        )
+                    )
+                )
             )
         }
-        val stringDetails = OpenFeatureAPI.getClient().getStringDetails("fdema-kotlin-flag-1.color", "default")
-        assertNull(stringDetails.errorCode)
-        assertNull(stringDetails.errorMessage)
-        assertNotNull(stringDetails.value)
-        assertNotEquals("default", stringDetails.value)
-        assertEquals(Reason.TARGETING_MATCH.name, stringDetails.reason)
-        assertNotNull(stringDetails.variant)
+        val intDetails = OpenFeatureAPI.getClient().getIntegerDetails("test-flag-1.my-integer", 0)
+        assertNull(intDetails.errorCode)
+        assertNull(intDetails.errorMessage)
+        assertNotNull(intDetails.value)
+        assertNotEquals(0, intDetails.value)
+        assertEquals(Reason.TARGETING_MATCH.name, intDetails.reason)
+        assertNotNull(intDetails.variant)
     }
 
     @Test
@@ -55,16 +65,25 @@ class ConfidenceIntegrationTests {
             OpenFeatureAPI.setProvider(
                 ConfidenceFeatureProvider.Builder(mockContext, clientSecret)
                     .build(),
-                MutableContext(targetingKey = UUID.randomUUID().toString())
+                MutableContext(
+                    targetingKey = UUID.randomUUID().toString(),
+                    attributes = mutableMapOf(
+                        "user" to Value.Structure(
+                            mapOf(
+                                "country" to Value.String("SE")
+                            )
+                        )
+                    )
+                )
             )
         }
         assertNotEquals(0L, cacheFile.length())
-        val stringDetails = OpenFeatureAPI.getClient().getStringDetails("fdema-kotlin-flag-1.color", "default")
-        assertNull(stringDetails.errorCode)
-        assertNull(stringDetails.errorMessage)
-        assertNotNull(stringDetails.value)
-        assertNotEquals("default", stringDetails.value)
-        assertEquals(Reason.TARGETING_MATCH.name, stringDetails.reason)
-        assertNotNull(stringDetails.variant)
+        val intDetails = OpenFeatureAPI.getClient().getIntegerDetails("test-flag-1.my-integer", 0)
+        assertNull(intDetails.errorCode)
+        assertNull(intDetails.errorMessage)
+        assertNotNull(intDetails.value)
+        assertNotEquals(0, intDetails.value)
+        assertEquals(Reason.TARGETING_MATCH.name, intDetails.reason)
+        assertNotNull(intDetails.variant)
     }
 }


### PR DESCRIPTION
A new secret key is used to connect to the Confidence org.`konfidens-e2e`. 
The older secret key stopped working after some backend changes. 

With the new key/org., we are also reading a new flag for our IT tests (e2e tests), which is the same flag used by the [iOS e2e tests](https://github.com/spotify/confidence-openfeature-provider-swift/blob/32e19096e4165c3c9a7d9d7c39096960ebce6d49/Tests/ConfidenceProviderTests/ConfidenceIntegrationTest.swift#L15).