### PR TITLE
Structure serializers & interactors

### DIFF
--- a/Provider/build.gradle.kts
+++ b/Provider/build.gradle.kts
@@ -12,7 +12,6 @@ object Versions {
     const val openFeatureSDK = "0.0.1-SNAPSHOT"
     const val okHttp = "4.10.0"
     const val kotlinxSerialization = "1.5.1"
-    const val gson = "2.10"
     const val coroutines = "1.7.1"
     const val junit = "4.13.2"
     const val kotlinMockito = "4.1.0"
@@ -64,7 +63,6 @@ dependencies {
     implementation(
         "org.jetbrains.kotlinx:kotlinx-serialization-json:${Versions.kotlinxSerialization}"
     )
-    implementation("com.google.code.gson:gson:${Versions.gson}")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}")
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.desugaringVersion}")
     testImplementation("junit:junit:${Versions.junit}")

--- a/Provider/src/main/java/dev/openfeature/contrib/providers/ConfidenceFeatureProvider.kt
+++ b/Provider/src/main/java/dev/openfeature/contrib/providers/ConfidenceFeatureProvider.kt
@@ -7,9 +7,8 @@ import dev.openfeature.contrib.providers.cache.ProviderCache
 import dev.openfeature.contrib.providers.cache.ProviderCache.CacheResolveResult
 import dev.openfeature.contrib.providers.cache.StorageFileCache
 import dev.openfeature.contrib.providers.client.ConfidenceClient
+import dev.openfeature.contrib.providers.client.ConfidenceRegion
 import dev.openfeature.contrib.providers.client.ConfidenceRemoteClient
-import dev.openfeature.contrib.providers.client.ConfidenceRemoteClient.ConfidenceRegion
-import dev.openfeature.contrib.providers.client.ConfidenceRemoteClient.ConfidenceRegion.EUROPE
 import dev.openfeature.contrib.providers.client.ResolveReason
 import dev.openfeature.sdk.EvaluationContext
 import dev.openfeature.sdk.FeatureProvider
@@ -70,12 +69,14 @@ class ConfidenceFeatureProvider private constructor(
         fun cache(cache: ProviderCache) = apply { this.cache = cache }
 
         fun build(): ConfidenceFeatureProvider {
-            val configuredRegion = region ?: EUROPE
+            val configuredRegion = region ?: ConfidenceRegion.EUROPE
+
             val configuredClient = client ?: ConfidenceRemoteClient(
                 clientSecret = clientSecret,
                 region = configuredRegion,
                 dispatcher = dispatcher
             )
+
             return ConfidenceFeatureProvider(
                 hooks ?: listOf(),
                 metadata ?: ConfidenceMetadata(),
@@ -96,7 +97,7 @@ class ConfidenceFeatureProvider private constructor(
         withContext(dispatcher) {
             try {
                 val (resolvedFlags, resolveToken) = client.resolve(listOf(), initialContext)
-                cache.refresh(resolvedFlags, resolveToken, initialContext)
+                cache.refresh(resolvedFlags.list, resolveToken, initialContext)
             } catch (_: Throwable) {
                 // Can't refresh cache at this time. Do we retry at a later time?
             }

--- a/Provider/src/main/java/dev/openfeature/contrib/providers/cache/InMemoryCache.kt
+++ b/Provider/src/main/java/dev/openfeature/contrib/providers/cache/InMemoryCache.kt
@@ -20,7 +20,7 @@ open class InMemoryCache : ProviderCache {
             values = resolvedFlags.associate {
                 it.flag to CacheEntry(
                     it.variant,
-                    Value.Structure(it.value?.asMap() ?: mapOf()),
+                    Value.Structure(it.value.asMap()),
                     it.reason
                 )
             },

--- a/Provider/src/main/java/dev/openfeature/contrib/providers/client/CommonTypes.kt
+++ b/Provider/src/main/java/dev/openfeature/contrib/providers/client/CommonTypes.kt
@@ -1,0 +1,28 @@
+package dev.openfeature.contrib.providers.client
+
+enum class ConfidenceRegion {
+    EUROPE,
+    USA
+}
+
+enum class ResolveReason {
+    // Unspecified enum.
+    RESOLVE_REASON_UNSPECIFIED,
+
+    // The flag was successfully resolved because one rule matched.
+    RESOLVE_REASON_MATCH,
+
+    // The flag could not be resolved because no rule matched.
+    RESOLVE_REASON_NO_SEGMENT_MATCH,
+
+    // The flag could not be resolved because the matching rule had no variant
+    // that could be assigned.
+    RESOLVE_REASON_NO_TREATMENT_MATCH,
+
+    // the flag could not be resolved because the targeting key
+    // is invalid
+    RESOLVE_REASON_TARGETING_KEY_ERROR,
+
+    // The flag could not be resolved because it was archived.
+    RESOLVE_REASON_FLAG_ARCHIVED
+}

--- a/Provider/src/main/java/dev/openfeature/contrib/providers/client/ConfidenceClient.kt
+++ b/Provider/src/main/java/dev/openfeature/contrib/providers/client/ConfidenceClient.kt
@@ -3,6 +3,6 @@ package dev.openfeature.contrib.providers.client
 import dev.openfeature.sdk.EvaluationContext
 
 interface ConfidenceClient {
-    suspend fun resolve(flags: List<String>, ctx: EvaluationContext): ResolveFlagsResponse
+    suspend fun resolve(flags: List<String>, ctx: EvaluationContext): ResolveFlags
     suspend fun apply(flags: List<AppliedFlag>, resolveToken: String)
 }

--- a/Provider/src/main/java/dev/openfeature/contrib/providers/client/ConfidenceRemoteClient.kt
+++ b/Provider/src/main/java/dev/openfeature/contrib/providers/client/ConfidenceRemoteClient.kt
@@ -1,39 +1,21 @@
 package dev.openfeature.contrib.providers.client
 
-import android.annotation.SuppressLint
-import com.google.gson.Gson
-import com.google.gson.GsonBuilder
-import com.google.gson.JsonArray
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonElement
-import com.google.gson.JsonNull
-import com.google.gson.JsonObject
-import com.google.gson.JsonPrimitive
-import com.google.gson.JsonSerializationContext
-import com.google.gson.JsonSerializer
-import com.google.gson.reflect.TypeToken
+import dev.openfeature.contrib.providers.client.network.ApplyFlagsInteractor
+import dev.openfeature.contrib.providers.client.network.ApplyFlagsInteractorImpl
+import dev.openfeature.contrib.providers.client.network.ApplyFlagsRequest
+import dev.openfeature.contrib.providers.client.network.ResolveFlagsInteractor
+import dev.openfeature.contrib.providers.client.network.ResolveFlagsInteractorImpl
+import dev.openfeature.contrib.providers.client.serializers.FlagsSerializer
 import dev.openfeature.sdk.EvaluationContext
-import dev.openfeature.sdk.MutableStructure
-import dev.openfeature.sdk.Structure
-import dev.openfeature.sdk.Value
-import dev.openfeature.sdk.exceptions.OpenFeatureError.GeneralError
-import dev.openfeature.sdk.exceptions.OpenFeatureError.ParseError
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
 import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.Response
-import java.lang.reflect.Type
-import java.text.SimpleDateFormat
 import java.time.Clock
-import java.time.Instant
-import java.util.Date
-import java.util.TimeZone
 
 class ConfidenceRemoteClient : ConfidenceClient {
     private val clientSecret: String
@@ -42,8 +24,14 @@ class ConfidenceRemoteClient : ConfidenceClient {
     private val headers: Headers
     private val clock: Clock
     private val dispatcher: CoroutineDispatcher
+    private val resolveInteractor: ResolveFlagsInteractor
+    private val applyInteractor: ApplyFlagsInteractor
 
-    constructor(clientSecret: String, region: ConfidenceRegion, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+    constructor(
+        clientSecret: String,
+        region: ConfidenceRegion,
+        dispatcher: CoroutineDispatcher = Dispatchers.IO
+    ) {
         this.clientSecret = clientSecret
         this.okHttpClient = OkHttpClient()
         this.headers = Headers.headersOf(
@@ -58,6 +46,18 @@ class ConfidenceRemoteClient : ConfidenceClient {
         }
         this.clock = Clock.systemUTC()
         this.dispatcher = dispatcher
+
+        this.resolveInteractor = ResolveFlagsInteractorImpl(
+            httpClient = okHttpClient,
+            baseUrl = baseUrl,
+            dispatcher = dispatcher
+        )
+
+        this.applyInteractor = ApplyFlagsInteractorImpl(
+            httpClient = okHttpClient,
+            baseUrl = baseUrl,
+            dispatcher = dispatcher
+        )
     }
 
     internal constructor(
@@ -77,400 +77,50 @@ class ConfidenceRemoteClient : ConfidenceClient {
         this.baseUrl = baseUrl.toString()
         this.clock = clock
         this.dispatcher = dispatcher
+
+        this.resolveInteractor = ResolveFlagsInteractorImpl(
+            httpClient = okHttpClient,
+            baseUrl = baseUrl.toString(),
+            dispatcher = dispatcher
+        )
+
+        this.applyInteractor = ApplyFlagsInteractorImpl(
+            httpClient = okHttpClient,
+            baseUrl = baseUrl.toString(),
+            dispatcher = dispatcher
+        )
     }
 
-    companion object {
-        private val gson = GsonBuilder()
-            .serializeNulls()
-            .setPrettyPrinting()
-            .registerTypeAdapter(Structure::class.java, StructureTypeAdapter())
-            .registerTypeAdapter(SchemaType.SchemaStruct::class.java, SchemaTypeAdapter())
-            .registerTypeAdapter(Instant::class.java, InstantTypeAdapter())
-            .create()
-    }
+    override suspend fun resolve(
+        flags: List<String>,
+        ctx: EvaluationContext
+    ): ResolveFlags {
+        val request = ResolveFlagsRequest(
+            flags.map { "flags/$it" },
+            ctx.toEvaluationContextStruct(),
+            clientSecret,
+            false
+        )
 
-    enum class ConfidenceRegion {
-        EUROPE,
-        USA
-    }
+        val networkResponse = resolveInteractor(request)
+        val bodyString = networkResponse.body!!.string()
 
-    override suspend fun resolve(flags: List<String>, ctx: EvaluationContext): ResolveFlagsResponse =
-        withContext(dispatcher) {
-            try {
-                val request = Request.Builder()
-                    .url("$baseUrl/v1/flags:resolve")
-                    .headers(headers)
-                    .post(
-                        gson.toJson(
-                            ResolveFlagsRequest(
-                                flags.map { "flags/$it" },
-                                getEvaluationContextStruct(ctx),
-                                clientSecret,
-                                false
-                            )
-                        ).toRequestBody()
-                    )
-                    .build()
-
-                okHttpClient.newCall(request).execute().use { response ->
-                    if (!response.isSuccessful) throw GeneralError("Unexpected code $response")
-                    return@withContext processResolveResponse(response)
-                }
-            } catch (err: Error) {
-                throw GeneralError("Error when executing resolve request: ${err.localizedMessage}")
+        // building the json class responsible for serializing the object
+        val networkJson = Json {
+            serializersModule = SerializersModule {
+                contextual(FlagsSerializer)
             }
         }
-
-    override suspend fun apply(flags: List<AppliedFlag>, resolveToken: String) = withContext(dispatcher) {
-        try {
-            val request = Request.Builder()
-                .url("$baseUrl/v1/flags:apply")
-                .headers(headers)
-                .post(
-                    gson.toJson(
-                        ApplyFlagsRequest(
-                            flags.map { AppliedFlag("flags/${it.flag}", it.applyTime) },
-                            clock.instant(),
-                            clientSecret,
-                            resolveToken
-                        )
-                    ).toRequestBody()
-                )
-                .build()
-
-            okHttpClient.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) throw GeneralError("Unexpected code $response")
-            }
-        } catch (err: Error) {
-            throw GeneralError("Error when executing resolve request: ${err.localizedMessage}")
-        }
+        return networkJson.decodeFromString(bodyString)
     }
 
-    private fun processResolveResponse(response: Response): ResolveFlagsResponse {
-        val type = object : TypeToken<ResolveFlagsResponse>() {}.type
-        val resolveFlagsResponse =
-            gson.fromJson<ResolveFlagsResponse?>(response.body!!.string(), type)
-        resolveFlagsResponse.resolvedFlags =
-            resolveFlagsResponse.resolvedFlags.map { resolvedFlag ->
-                // Remove resource type prefix "flags/"
-                val flagNameSplits = resolvedFlag.flag.split("/")
-                if (flagNameSplits.count() < 2 || flagNameSplits[0] != "flags") {
-                    throw ParseError("Unexpected flag name in resolve flag data: ${resolvedFlag.flag}")
-                }
-                // Verify generic JSON->Value parsing against Confidence-defined flagSchema
-                // Apply Value-type translations according to flagSchema, if needed
-                val newValue: Map<String, Value>? = resolvedFlag.value?.asMap()?.mapValues {
-                    verifyAndConvert(
-                        it.key,
-                        it.value,
-                        resolvedFlag.flagSchema ?: SchemaType.SchemaStruct(mapOf())
-                    )
-                }
-                when (newValue) {
-                    null -> resolvedFlag.copy(flag = flagNameSplits[1])
-                    else -> resolvedFlag.copy(
-                        flag = flagNameSplits[1],
-                        value = MutableStructure(newValue.toMutableMap())
-                    )
-                }
-            }
-        return resolveFlagsResponse
+    override suspend fun apply(flags: List<AppliedFlag>, resolveToken: String) {
+        val request = ApplyFlagsRequest(
+            flags.map { AppliedFlag("flags/${it.flag}", it.applyTime) },
+            clock.instant(),
+            clientSecret,
+            resolveToken
+        )
+        applyInteractor(request)
     }
-
-    private fun verifyAndConvert(key: String, value: Value, schemaStruct: SchemaType.SchemaStruct): Value {
-        return when (schemaStruct.schema[key]) {
-            is SchemaType.StringSchema -> when (value) {
-                is Value.Instant -> Value.String(value.instant.toISO8601String())
-                is Value.String -> value
-                is Value.Null -> value
-                else -> { throw ParseError("Incompatible value \"$key\" for schema") }
-            }
-            SchemaType.DoubleSchema -> when (value) {
-                is Value.Integer -> {
-                    val intValue = value.asInteger()
-                        ?: throw GeneralError("Internal error when processing Integer value $value")
-                    Value.Double(intValue.toDouble())
-                }
-                is Value.Double -> value
-                is Value.Null -> value
-                else -> { throw ParseError("Incompatible value \"$key\" for schema") }
-            }
-            is SchemaType.SchemaStruct -> when (value) {
-                is Value.Structure -> {
-                    return Value.Structure(
-                        value.asStructure()?.mapValues {
-                            verifyAndConvert(it.key, it.value, schemaStruct.schema[key] as SchemaType.SchemaStruct)
-                        }
-                            ?: mapOf()
-                    )
-                }
-                is Value.Null -> value
-                else -> { throw ParseError("Incompatible value \"$key\" for schema") }
-            }
-            SchemaType.BoolSchema -> when (value) {
-                is Value.Boolean -> value
-                is Value.Null -> value
-                else -> { throw ParseError("Incompatible value \"$key\" for schema") }
-            }
-            SchemaType.IntSchema -> when (value) {
-                is Value.Integer -> value
-                is Value.Null -> value
-                else -> { throw ParseError("Incompatible value \"$key\" for schema") }
-            }
-            null -> { throw ParseError("Couldn't find value \"$key\" in schema") }
-        }
-    }
-
-    private fun getEvaluationContextStruct(ctx: EvaluationContext): Structure {
-        val ctxAttributes: MutableMap<String, Value> =
-            mutableMapOf(Pair("targeting_key", Value.String(ctx.getTargetingKey())))
-        ctxAttributes.putAll(ctx.asMap())
-        return MutableStructure(ctxAttributes)
-    }
-}
-
-@SuppressLint("SimpleDateFormat")
-private val datetimeFormatter =
-    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").apply { timeZone = TimeZone.getTimeZone("UTC") }
-
-private fun Date.toISO8601String(): String = datetimeFormatter.format(this)
-
-/*
- * Adapters
- */
-
-class SchemaTypeAdapter :
-    JsonDeserializer<SchemaType.SchemaStruct>,
-    JsonSerializer<SchemaType.SchemaStruct> {
-    override fun deserialize(
-        json: JsonElement?,
-        typeOfT: Type?,
-        context: JsonDeserializationContext?
-    ): SchemaType.SchemaStruct {
-        return convertSchemaStruct(json)
-    }
-
-    private fun convertSchemaStruct(value: JsonElement?): SchemaType.SchemaStruct {
-        val map: MutableMap<String, SchemaType> = mutableMapOf()
-        val schemaData: JsonElement? = value?.asJsonObject?.asMap()?.get("schema")
-        val iterator = schemaData?.asJsonObject?.entrySet()?.iterator()
-        while (iterator?.hasNext() == true) {
-            val next: MutableMap.MutableEntry<String, JsonElement> = iterator.next()
-            map[next.key] = convertSchemaType(next.value)
-        }
-        return SchemaType.SchemaStruct(map)
-    }
-
-    private fun convertSchemaType(value: JsonElement): SchemaType {
-        if (value.asJsonObject.keySet().contains("stringSchema")) {
-            return SchemaType.StringSchema
-        } else if (value.asJsonObject.keySet().contains("structSchema")) {
-            return convertSchemaStruct(value.asJsonObject.get("structSchema"))
-        } else if (value.asJsonObject.keySet().contains("boolSchema")) {
-            return SchemaType.BoolSchema
-        } else if (value.asJsonObject.keySet().contains("intSchema")) {
-            return SchemaType.IntSchema
-        } else if (value.asJsonObject.keySet().contains("doubleSchema")) {
-            return SchemaType.DoubleSchema
-        }
-        throw ParseError("Unrecognized flag schema identifier: ${value.asJsonObject.keySet()}")
-    }
-
-    override fun serialize(
-        src: SchemaType.SchemaStruct?,
-        typeOfSrc: Type?,
-        context: JsonSerializationContext?
-    ): JsonElement {
-        throw GeneralError("Serialization of flag schema not supported")
-    }
-}
-
-class StructureTypeAdapter : JsonDeserializer<Structure>, JsonSerializer<Structure> {
-    override fun deserialize(
-        json: JsonElement?,
-        typeOfT: Type?,
-        context: JsonDeserializationContext?
-    ): Structure {
-        val map: MutableMap<String, Value> = mutableMapOf()
-        val iterator = json?.asJsonObject?.entrySet()?.iterator()
-        while (iterator?.hasNext() == true) {
-            val next: MutableMap.MutableEntry<String, JsonElement> = iterator.next()
-            map[next.key] = convert(next.value)
-        }
-        return MutableStructure(map)
-    }
-
-    /**
-     * Generic JSON->Value conversion that doesn't use Confidence schema and rather infer Value type
-     * from the format and type of the JsonElement itself
-     */
-    private fun convert(value: JsonElement): Value {
-        if (value.isJsonPrimitive) {
-            if (value.asJsonPrimitive.isString) {
-                return try {
-                    val date = datetimeFormatter.parse(value.asString)
-                        ?: throw IllegalArgumentException("Cannot parse ${value.asString} to date.")
-                    Value.Instant(date)
-                } catch (e: Exception) {
-                    Value.String(value.asString)
-                }
-            } else if (value.asJsonPrimitive.isNumber) {
-                return if (value.asDouble.rem(1).equals(0.0)) {
-                    Value.Integer(value.asInt)
-                } else {
-                    Value.Double(value.asDouble)
-                }
-            } else if (value.asJsonPrimitive.isBoolean) {
-                return Value.Boolean(value.asBoolean)
-            }
-        } else if (value.isJsonNull) {
-            return Value.Null
-        } else if (value.isJsonArray) {
-            return Value.List(value.asJsonArray.map { element -> convert(element) })
-        } else if (value.isJsonObject) {
-            return Value.Structure(value.asJsonObject.asMap().mapValues { v -> convert(v.value) })
-        }
-        throw ParseError("Couldn't parse JSON value: $value")
-    }
-
-    override fun serialize(
-        src: Structure?,
-        typeOfSrc: Type?,
-        context: JsonSerializationContext?
-    ): JsonElement {
-        return convertStructure(src)
-    }
-
-    private fun convertStructure(src: Structure?): JsonElement {
-        val jsonObject = JsonObject()
-        src?.asMap()?.forEach { entry: Map.Entry<String, Value> ->
-            when (val value = entry.value) {
-                is Value.String -> jsonObject.addProperty(entry.key, value.asString())
-                is Value.Boolean -> jsonObject.addProperty(entry.key, value.asBoolean())
-                is Value.Instant -> jsonObject.add(
-                    entry.key,
-                    value.asInstant()?.toISO8601String()?.let {
-                        Gson().toJsonTree(it)
-                    } ?: JsonNull.INSTANCE
-                )
-                is Value.Double -> jsonObject.addProperty(entry.key, value.asDouble())
-                is Value.Integer -> jsonObject.addProperty(entry.key, value.asInteger())
-                is Value.List -> jsonObject.add(entry.key, convertArray(entry.value.asList()))
-                Value.Null -> jsonObject.add(entry.key, null)
-                is Value.Structure -> {
-                    val attributes = value.asStructure()?.toMutableMap()
-                    if (attributes != null) {
-                        jsonObject.add(entry.key, convertStructure(MutableStructure(attributes)))
-                    } else {
-                        throw GeneralError("Error while serializing nested Structure")
-                    }
-                }
-            }
-        }
-        return jsonObject
-    }
-
-    private fun convertArray(value: List<Value>?): JsonArray {
-        val jsonArray = JsonArray()
-        value?.forEach { v ->
-            when (v) {
-                is Value.String -> jsonArray.add(v.string)
-                is Value.Boolean -> jsonArray.add(v.boolean)
-                is Value.Instant -> jsonArray.add(v.asInstant().toString())
-                is Value.Double -> jsonArray.add(v.asDouble())
-                is Value.Integer -> jsonArray.add(v.asInteger())
-                is Value.List -> jsonArray.add(convertArray(v.asList()))
-                Value.Null -> jsonArray.add(JsonNull.INSTANCE)
-                is Value.Structure -> {
-                    val attributes = v.asStructure()?.toMutableMap()
-                    if (attributes != null) {
-                        jsonArray.add(convertStructure(MutableStructure(attributes)))
-                    } else {
-                        throw GeneralError("Error while serializing nested Structure")
-                    }
-                }
-            }
-        }
-        return jsonArray
-    }
-}
-
-class InstantTypeAdapter : JsonDeserializer<Instant>, JsonSerializer<Instant> {
-    override fun deserialize(
-        json: JsonElement?,
-        typeOfT: Type?,
-        context: JsonDeserializationContext?
-    ): Instant {
-        val asString = json?.asJsonPrimitive?.asString
-        return Instant.parse(asString)
-    }
-
-    override fun serialize(
-        src: Instant?,
-        typeOfSrc: Type?,
-        context: JsonSerializationContext?
-    ): JsonElement {
-        return JsonPrimitive(src?.toString())
-    }
-}
-
-/*
- * Data models
- */
-
-data class ResolveFlagsRequest(
-    var flags: List<String>,
-    var evaluationContext: Structure,
-    var clientSecret: String,
-    var apply: Boolean
-)
-
-data class ResolveFlagsResponse(var resolvedFlags: List<ResolvedFlag>, var resolveToken: String)
-
-data class ResolvedFlag(
-    var flag: String,
-    var variant: String,
-    var value: Structure?,
-    var flagSchema: SchemaType.SchemaStruct?,
-    var reason: ResolveReason
-)
-
-data class ApplyFlagsRequest(
-    var flags: List<AppliedFlag>,
-    var sendTime: Instant,
-    var clientSecret: String,
-    var resolveToken: String
-)
-
-data class AppliedFlag(
-    var flag: String,
-    var applyTime: Instant
-)
-
-sealed interface SchemaType {
-    data class SchemaStruct(
-        var schema: Map<String, SchemaType>
-    ) : SchemaType
-    object IntSchema : SchemaType
-    object DoubleSchema : SchemaType
-    object StringSchema : SchemaType
-    object BoolSchema : SchemaType
-}
-
-enum class ResolveReason {
-    // Unspecified enum.
-    RESOLVE_REASON_UNSPECIFIED,
-
-    // The flag was successfully resolved because one rule matched.
-    RESOLVE_REASON_MATCH,
-
-    // The flag could not be resolved because no rule matched.
-    RESOLVE_REASON_NO_SEGMENT_MATCH,
-
-    // The flag could not be resolved because the matching rule had no variant
-    // that could be assigned.
-    RESOLVE_REASON_NO_TREATMENT_MATCH,
-
-    // The flag could not be resolved because it was archived.
-    RESOLVE_REASON_FLAG_ARCHIVED
 }

--- a/Provider/src/main/java/dev/openfeature/contrib/providers/client/Extensions.kt
+++ b/Provider/src/main/java/dev/openfeature/contrib/providers/client/Extensions.kt
@@ -1,0 +1,52 @@
+package dev.openfeature.contrib.providers.client
+
+import dev.openfeature.sdk.EvaluationContext
+import dev.openfeature.sdk.MutableStructure
+import dev.openfeature.sdk.Structure
+import dev.openfeature.sdk.Value
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CompletionHandler
+import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.Response
+import java.io.IOException
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+internal fun EvaluationContext.toEvaluationContextStruct(): Structure {
+    val ctxAttributes: MutableMap<String, Value> =
+        mutableMapOf(Pair("targeting_key", Value.String(getTargetingKey())))
+    ctxAttributes.putAll(asMap())
+    return MutableStructure(ctxAttributes)
+}
+
+internal suspend inline fun Call.await(): Response {
+    return suspendCancellableCoroutine { continuation ->
+        val callback = ContinuationCallback(this, continuation)
+        enqueue(callback)
+        continuation.invokeOnCancellation(callback)
+    }
+}
+
+internal class ContinuationCallback(
+    private val call: Call,
+    private val continuation: CancellableContinuation<Response>
+) : Callback, CompletionHandler {
+
+    override fun onResponse(call: Call, response: Response) {
+        continuation.resume(response)
+    }
+
+    override fun onFailure(call: Call, e: IOException) {
+        if (!call.isCanceled()) {
+            continuation.resumeWithException(e)
+        }
+    }
+
+    override fun invoke(cause: Throwable?) {
+        try {
+            call.cancel()
+        } catch (_: Throwable) {}
+    }
+}

--- a/Provider/src/main/java/dev/openfeature/contrib/providers/client/Types.kt
+++ b/Provider/src/main/java/dev/openfeature/contrib/providers/client/Types.kt
@@ -1,0 +1,51 @@
+package dev.openfeature.contrib.providers.client
+
+import dev.openfeature.sdk.MutableStructure
+import dev.openfeature.sdk.Structure
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+import java.time.Instant
+
+@Serializable
+data class AppliedFlag(
+    val flag: String,
+    @Contextual
+    val applyTime: Instant
+)
+
+@Serializable
+data class ResolveFlagsRequest(
+    val flags: List<String>,
+    @Contextual
+    val evaluationContext: Structure,
+    val clientSecret: String,
+    val apply: Boolean
+)
+
+@Serializable
+data class ResolveFlags(
+    @Contextual
+    val resolvedFlags: Flags,
+    val resolveToken: String
+)
+
+data class Flags(
+    val list: List<ResolvedFlag>
+)
+
+data class ResolvedFlag(
+    val flag: String,
+    val variant: String,
+    val value: Structure = MutableStructure(mutableMapOf()),
+    val reason: ResolveReason
+)
+
+sealed interface SchemaType {
+    data class SchemaStruct(
+        var schema: Map<String, SchemaType>
+    ) : SchemaType
+    object IntSchema : SchemaType
+    object DoubleSchema : SchemaType
+    object StringSchema : SchemaType
+    object BoolSchema : SchemaType
+}

--- a/Provider/src/main/java/dev/openfeature/contrib/providers/client/network/ApplyFlagsInteractor.kt
+++ b/Provider/src/main/java/dev/openfeature/contrib/providers/client/network/ApplyFlagsInteractor.kt
@@ -1,0 +1,66 @@
+package dev.openfeature.contrib.providers.client.network
+
+import dev.openfeature.contrib.providers.client.AppliedFlag
+import dev.openfeature.contrib.providers.client.await
+import dev.openfeature.contrib.providers.client.serializers.InstantSerializer
+import dev.openfeature.contrib.providers.client.serializers.StructureSerializer
+import dev.openfeature.contrib.providers.client.serializers.UUIDSerializer
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
+import okhttp3.Headers
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import java.time.Instant
+
+internal interface ApplyFlagsInteractor : suspend (ApplyFlagsRequest) -> (Response)
+
+internal class ApplyFlagsInteractorImpl(
+    private val httpClient: OkHttpClient,
+    private val baseUrl: String,
+    private val dispatcher: CoroutineDispatcher
+) : ApplyFlagsInteractor {
+
+    private val headers by lazy {
+        Headers.headersOf(
+            "Content-Type",
+            "application/json",
+            "Accept",
+            "application/json"
+        )
+    }
+    override suspend fun invoke(request: ApplyFlagsRequest): Response =
+        withContext(dispatcher) {
+            val httpRequest = Request.Builder()
+                .url("$baseUrl/v1/flags:apply")
+                .headers(headers)
+                .post(json.encodeToString(request).toRequestBody())
+                .build()
+
+            return@withContext httpClient.newCall(httpRequest).await()
+        }
+}
+
+@Serializable
+internal data class ApplyFlagsRequest(
+    val flags: List<AppliedFlag>,
+    @Contextual
+    val sendTime: Instant,
+    val clientSecret: String,
+    val resolveToken: String
+)
+
+private val json = Json {
+    serializersModule = SerializersModule {
+        contextual(UUIDSerializer)
+        contextual(InstantSerializer)
+        contextual(StructureSerializer)
+    }
+}

--- a/Provider/src/main/java/dev/openfeature/contrib/providers/client/network/ResolveFlagsInteractor.kt
+++ b/Provider/src/main/java/dev/openfeature/contrib/providers/client/network/ResolveFlagsInteractor.kt
@@ -1,0 +1,55 @@
+package dev.openfeature.contrib.providers.client.network
+
+import dev.openfeature.contrib.providers.client.ResolveFlagsRequest
+import dev.openfeature.contrib.providers.client.await
+import dev.openfeature.contrib.providers.client.serializers.InstantSerializer
+import dev.openfeature.contrib.providers.client.serializers.StructureSerializer
+import dev.openfeature.contrib.providers.client.serializers.UUIDSerializer
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
+import okhttp3.Headers
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+
+interface ResolveFlagsInteractor : suspend (ResolveFlagsRequest) -> (Response)
+
+internal class ResolveFlagsInteractorImpl(
+    private val httpClient: OkHttpClient,
+    private val baseUrl: String,
+    private val dispatcher: CoroutineDispatcher
+) : ResolveFlagsInteractor {
+
+    private val headers by lazy {
+        Headers.headersOf(
+            "Content-Type",
+            "application/json",
+            "Accept",
+            "application/json"
+        )
+    }
+    override suspend fun invoke(request: ResolveFlagsRequest): Response =
+        withContext(dispatcher) {
+            val jsonRequest = json.encodeToString(request)
+            val httpRequest = Request.Builder()
+                .url("$baseUrl/v1/flags:resolve")
+                .headers(headers)
+                .post(jsonRequest.toRequestBody())
+                .build()
+
+            return@withContext httpClient.newCall(httpRequest).await()
+        }
+}
+
+private val json = Json {
+    serializersModule = SerializersModule {
+        contextual(UUIDSerializer)
+        contextual(InstantSerializer)
+        contextual(StructureSerializer)
+    }
+}

--- a/Provider/src/main/java/dev/openfeature/contrib/providers/client/serializers/InstantSerializer.kt
+++ b/Provider/src/main/java/dev/openfeature/contrib/providers/client/serializers/InstantSerializer.kt
@@ -1,0 +1,18 @@
+package dev.openfeature.contrib.providers.client.serializers
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.time.Instant
+
+internal object InstantSerializer : KSerializer<Instant> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("Instant", PrimitiveKind.LONG)
+    override fun serialize(encoder: Encoder, value: Instant) =
+        encoder.encodeString(value.toString())
+    override fun deserialize(decoder: Decoder): Instant =
+        Instant.parse(decoder.decodeString())
+}

--- a/Provider/src/main/java/dev/openfeature/contrib/providers/client/serializers/Serializers.kt
+++ b/Provider/src/main/java/dev/openfeature/contrib/providers/client/serializers/Serializers.kt
@@ -1,0 +1,266 @@
+package dev.openfeature.contrib.providers.client.serializers
+
+import dev.openfeature.contrib.providers.client.Flags
+import dev.openfeature.contrib.providers.client.ResolveReason
+import dev.openfeature.contrib.providers.client.ResolvedFlag
+import dev.openfeature.contrib.providers.client.SchemaType
+import dev.openfeature.sdk.DateSerializer
+import dev.openfeature.sdk.MutableStructure
+import dev.openfeature.sdk.Structure
+import dev.openfeature.sdk.Value
+import dev.openfeature.sdk.ValueSerializer
+import dev.openfeature.sdk.exceptions.OpenFeatureError
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.encoding.encodeStructure
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.util.UUID
+
+/***
+ * the struct serializer needed for sending the resolve request
+ */
+
+internal object StructureSerializer : KSerializer<Structure> {
+    override val descriptor: SerialDescriptor =
+        MapSerializer(String.serializer(), String.serializer()).descriptor
+
+    override fun deserialize(decoder: Decoder): Structure {
+        error("no deserializer is needed")
+    }
+
+    override fun serialize(encoder: Encoder, value: Structure) {
+        encoder.encodeStructure(descriptor) {
+            value.asMap().forEach { (key, value) ->
+                encodeStringElement(descriptor, 0, key)
+                encodeSerializableElement(descriptor, 1, StructureValueSerializer, value)
+            }
+        }
+    }
+}
+
+private object StructureValueSerializer : KSerializer<Value> {
+    override val descriptor: SerialDescriptor
+        get() = ValueSerializer.descriptor
+
+    override fun deserialize(decoder: Decoder): Value {
+        error("we don't need to deserialize here")
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    override fun serialize(encoder: Encoder, value: Value) {
+        when (value) {
+            is Value.String -> encoder.encodeString(value.string)
+            is Value.Boolean -> encoder.encodeBoolean(value.boolean)
+            is Value.Double -> encoder.encodeDouble(value.double)
+            is Value.Instant -> encoder.encodeSerializableValue(
+                DateSerializer,
+                value.instant
+            )
+
+            is Value.Integer -> encoder.encodeInt(value.integer)
+            is Value.List -> encoder.encodeSerializableValue(
+                ListSerializer(StructureValueSerializer),
+                value.list
+            )
+
+            Value.Null -> encoder.encodeNull()
+            is Value.Structure -> encoder.encodeSerializableValue(
+                StructureSerializer,
+                MutableStructure(value.structure.toMutableMap())
+            )
+        }
+    }
+}
+
+object UUIDSerializer : KSerializer<UUID> {
+    override val descriptor = PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): UUID {
+        return UUID.fromString(decoder.decodeString())
+    }
+
+    override fun serialize(encoder: Encoder, value: UUID) {
+        encoder.encodeString(value.toString())
+    }
+}
+
+/***
+ * the serializers needed for serializing the resolve flags response
+ */
+
+internal object SchemaTypeSerializer : KSerializer<SchemaType.SchemaStruct> {
+    override val descriptor: SerialDescriptor
+        get() = MapSerializer(String.serializer(), String.serializer()).descriptor
+
+    override fun deserialize(decoder: Decoder): SchemaType.SchemaStruct {
+        val jsonDecoder = decoder as JsonDecoder
+        val jsonElement = jsonDecoder.decodeJsonElement()
+        val schemaMap = mutableMapOf<String, SchemaType>()
+        for ((key, value) in jsonElement.jsonObject) {
+            schemaMap[key] = value.convertToSchemaTypeValue()
+        }
+        return SchemaType.SchemaStruct(schemaMap)
+    }
+
+    override fun serialize(encoder: Encoder, value: SchemaType.SchemaStruct) {
+        // we never serialize the object to send it over the wire
+        error("no serialization is needed")
+    }
+}
+
+internal object NetworkResolvedFlagSerializer : KSerializer<ResolvedFlag> {
+    override val descriptor: SerialDescriptor =
+        MapSerializer(String.serializer(), String.serializer()).descriptor
+
+    override fun deserialize(decoder: Decoder): ResolvedFlag {
+        val jsonDecoder = decoder as JsonDecoder
+        val json = jsonDecoder.decodeJsonElement().jsonObject
+        val flag = json["flag"].toString().split("/")
+            .last()
+            .replace("\"", "")
+
+        val variant = json["variant"]
+            .toString()
+            .replace("\"", "")
+
+        val resolvedReason = Json.decodeFromString<ResolveReason>(json["reason"].toString())
+        val flagSchemaJsonElement = json["flagSchema"]
+
+        val schemasJson = if (flagSchemaJsonElement != null && flagSchemaJsonElement != JsonNull) {
+            flagSchemaJsonElement.jsonObject["schema"]
+        } else {
+            null
+        }
+
+        return if (schemasJson != null) {
+            val flagSchema =
+                Json.decodeFromString(SchemaTypeSerializer, schemasJson.toString())
+            val valueJson = json["value"].toString()
+            val values: Structure =
+                Json.decodeFromString(FlagValueSerializer(flagSchema), valueJson)
+
+            if (flagSchema.schema.size != values.asMap().size) {
+                throw OpenFeatureError.ParseError("Unexpected flag name in resolve flag data: $flag")
+            }
+
+            ResolvedFlag(
+                flag = flag,
+                variant = variant,
+                reason = resolvedReason,
+                value = values
+            )
+        } else {
+            ResolvedFlag(
+                flag = flag,
+                variant = variant,
+                reason = resolvedReason,
+                value = MutableStructure(mutableMapOf())
+            )
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: ResolvedFlag) {
+        error("no serialization is needed")
+    }
+}
+
+internal class FlagValueSerializer(
+    private val schemaStruct: SchemaType.SchemaStruct,
+    override val descriptor: SerialDescriptor =
+        MapSerializer(String.serializer(), String.serializer()).descriptor
+) : KSerializer<Structure> {
+    override fun deserialize(decoder: Decoder): Structure {
+        val valueMap = mutableMapOf<String, Value>()
+        val jsonDecoder = decoder as JsonDecoder
+        val jsonElement = jsonDecoder.decodeJsonElement()
+        for ((key, value) in jsonElement.jsonObject) {
+            schemaStruct.schema[key]?.let {
+                valueMap[key] = value.convertToValue(key, it)
+            } ?: throw OpenFeatureError.ParseError("Couldn't find value \"$key\" in schema")
+        }
+
+        return MutableStructure(valueMap)
+    }
+
+    override fun serialize(encoder: Encoder, value: Structure) {
+        error("no serialization is needed")
+    }
+}
+
+internal object FlagsSerializer : KSerializer<Flags> {
+    override val descriptor: SerialDescriptor
+        get() = ListSerializer(String.serializer()).descriptor
+
+    override fun deserialize(decoder: Decoder): Flags {
+        val list = mutableListOf<ResolvedFlag>()
+        val jsonDecoder = decoder as JsonDecoder
+        val array = jsonDecoder.decodeJsonElement().jsonArray
+        for (json in array) {
+            list.add(Json.decodeFromString(NetworkResolvedFlagSerializer, json.toString()))
+        }
+        return Flags(list)
+    }
+
+    override fun serialize(encoder: Encoder, value: Flags) {
+        error("flags won't be serialized")
+    }
+}
+
+private fun JsonElement.convertToValue(key: String, schemaType: SchemaType): Value = when (schemaType) {
+    is SchemaType.BoolSchema -> toString().toBooleanStrictOrNull()?.let(Value::Boolean) ?: Value.Null
+    is SchemaType.DoubleSchema -> {
+        toString().toDoubleOrNull()?.let(Value::Double) ?: Value.Null
+    }
+    is SchemaType.IntSchema -> {
+        // passing double number to an integer schema
+        if (toString().contains(".")) {
+            throw OpenFeatureError.ParseError("Incompatible value \"$key\" for schema")
+        }
+        toString().toIntOrNull()?.let(Value::Integer) ?: Value.Null
+    }
+    is SchemaType.SchemaStruct -> {
+        if (jsonObject.isEmpty()) {
+            Value.Null
+        } else {
+            val serializedMap = Json.decodeFromString(
+                FlagValueSerializer(schemaType),
+                jsonObject.toString()
+            ).asMap()
+
+            Value.Structure(serializedMap)
+        }
+    }
+    is SchemaType.StringSchema -> if (!jsonPrimitive.isString) {
+        Value.Null
+    } else {
+        Value.String(toString().replace("\"", ""))
+    }
+}
+
+private fun JsonElement.convertToSchemaTypeValue(): SchemaType = when {
+    jsonObject.keys.contains("stringSchema") -> SchemaType.StringSchema
+    jsonObject.keys.contains("doubleSchema") -> SchemaType.DoubleSchema
+    jsonObject.keys.contains("intSchema") -> SchemaType.IntSchema
+    jsonObject.keys.contains("boolSchema") -> SchemaType.BoolSchema
+    jsonObject.keys.contains("structSchema") -> {
+        val value = jsonObject["structSchema"]!!.jsonObject["schema"]
+        SchemaType.SchemaStruct(
+            Json.decodeFromString(SchemaTypeSerializer, value.toString()).schema
+        )
+    }
+    else -> error("not a valid schema")
+}

--- a/Provider/src/test/java/dev/openfeature/contrib/providers/StorageFileCacheTests.kt
+++ b/Provider/src/test/java/dev/openfeature/contrib/providers/StorageFileCacheTests.kt
@@ -3,10 +3,10 @@ package dev.openfeature.contrib.providers
 import android.content.Context
 import dev.openfeature.contrib.providers.cache.StorageFileCache
 import dev.openfeature.contrib.providers.client.ConfidenceClient
-import dev.openfeature.contrib.providers.client.ResolveFlagsResponse
+import dev.openfeature.contrib.providers.client.Flags
+import dev.openfeature.contrib.providers.client.ResolveFlags
 import dev.openfeature.contrib.providers.client.ResolveReason
 import dev.openfeature.contrib.providers.client.ResolvedFlag
-import dev.openfeature.contrib.providers.client.SchemaType
 import dev.openfeature.sdk.MutableContext
 import dev.openfeature.sdk.MutableStructure
 import dev.openfeature.sdk.Reason
@@ -25,41 +25,28 @@ import java.time.Instant
 
 class StorageFileCacheTests {
     private val instant = Instant.parse("2023-03-01T14:01:46Z")
-    private val resolvedFlags = listOf(
-        ResolvedFlag(
-            "fdema-kotlin-flag-1",
-            "flags/fdema-kotlin-flag-1/variants/variant-1",
-            MutableStructure(
-                mutableMapOf(
-                    "mystring" to Value.String("red"),
-                    "myboolean" to Value.Boolean(false),
-                    "myinteger" to Value.Integer(7),
-                    "mydouble" to Value.Double(3.14),
-                    "mydate" to Value.String(instant.toString()),
-                    "mystruct" to Value.Structure(
-                        mapOf(
-                            "innerString" to Value.String("innerValue")
-                        )
-                    ),
-                    "mynull" to Value.Null
-                )
-            ),
-            SchemaType.SchemaStruct(
-                mapOf(
-                    "mystring" to SchemaType.StringSchema,
-                    "myboolean" to SchemaType.BoolSchema,
-                    "myinteger" to SchemaType.IntSchema,
-                    "mydouble" to SchemaType.DoubleSchema,
-                    "mydate" to SchemaType.StringSchema,
-                    "mystruct" to SchemaType.SchemaStruct(
-                        mapOf(
-                            "innerString" to SchemaType.StringSchema
-                        )
-                    ),
-                    "mynull" to SchemaType.StringSchema
-                )
-            ),
-            ResolveReason.RESOLVE_REASON_MATCH
+    private val resolvedFlags = Flags(
+        listOf(
+            ResolvedFlag(
+                "fdema-kotlin-flag-1",
+                "flags/fdema-kotlin-flag-1/variants/variant-1",
+                MutableStructure(
+                    mutableMapOf(
+                        "mystring" to Value.String("red"),
+                        "myboolean" to Value.Boolean(false),
+                        "myinteger" to Value.Integer(7),
+                        "mydouble" to Value.Double(3.14),
+                        "mydate" to Value.String(instant.toString()),
+                        "mystruct" to Value.Structure(
+                            mapOf(
+                                "innerString" to Value.String("innerValue")
+                            )
+                        ),
+                        "mynull" to Value.Null
+                    )
+                ),
+                ResolveReason.RESOLVE_REASON_MATCH
+            )
         )
     )
     private val mockContext: Context = mock()
@@ -73,7 +60,7 @@ class StorageFileCacheTests {
     fun testOfflineScenarioLoadsStoredCache() = runTest {
         val mockClient: ConfidenceClient = mock()
         val cache1 = StorageFileCache(mockContext)
-        whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(ResolveFlagsResponse(resolvedFlags, "token1"))
+        whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(ResolveFlags(resolvedFlags, "token1"))
         val provider1 = ConfidenceFeatureProvider.Builder(mockContext, "")
             .client(mockClient)
             .cache(cache1)


### PR DESCRIPTION
* Drop gson
* Add a skeleton to use interactors
* Rely fully on the schemas that we receive from the backend, no more verification is needed any more and we don’t first serialize objects using json primitives but directly from the schema received from the network.