### PR TITLE
Remove the builder pattern from the provider

### DIFF
--- a/Provider/src/test/java/dev/openfeature/contrib/providers/ConfidenceFeatureProviderTests.kt
+++ b/Provider/src/test/java/dev/openfeature/contrib/providers/ConfidenceFeatureProviderTests.kt
@@ -86,11 +86,13 @@ internal class ConfidenceFeatureProviderTests {
     @Test
     fun testMatching() = runTest {
         val testDispatcher = UnconfinedTestDispatcher(testScheduler)
-        val confidenceFeatureProvider = ConfidenceFeatureProvider.Builder(mockContext, "")
-            .cache(InMemoryCache())
-            .client(mockClient)
-            .dispatcher(testDispatcher)
-            .build()
+        val confidenceFeatureProvider = ConfidenceFeatureProvider.create(
+            context = mockContext,
+            clientSecret = "",
+            cache = InMemoryCache(),
+            client = mockClient,
+            dispatcher = testDispatcher
+        )
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(ResolveFlags(resolvedFlags, "token1"))
         runBlocking {
             confidenceFeatureProvider.initialize(MutableContext("foo"))
@@ -157,11 +159,13 @@ internal class ConfidenceFeatureProviderTests {
     @Test
     fun testDelayedApply() = runTest {
         val testDispatcher = UnconfinedTestDispatcher(testScheduler)
-        val confidenceFeatureProvider = ConfidenceFeatureProvider.Builder(mockContext, "")
-            .cache(InMemoryCache())
-            .client(mockClient)
-            .dispatcher(testDispatcher)
-            .build()
+        val confidenceFeatureProvider = ConfidenceFeatureProvider.create(
+            context = mockContext,
+            clientSecret = "",
+            cache = InMemoryCache(),
+            client = mockClient,
+            dispatcher = testDispatcher
+        )
         val cacheFile = File(mockContext.filesDir, APPLY_FILE_NAME)
 
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(ResolveFlags(resolvedFlags, "token1"))
@@ -279,11 +283,13 @@ internal class ConfidenceFeatureProviderTests {
     @Test
     fun testApplyOnMultipleEvaluations() = runTest {
         val testDispatcher = UnconfinedTestDispatcher(testScheduler)
-        val confidenceFeatureProvider = ConfidenceFeatureProvider.Builder(mockContext, "")
-            .cache(InMemoryCache())
-            .client(mockClient)
-            .dispatcher(testDispatcher)
-            .build()
+        val confidenceFeatureProvider = ConfidenceFeatureProvider.create(
+            context = mockContext,
+            clientSecret = "",
+            cache = InMemoryCache(),
+            client = mockClient,
+            dispatcher = testDispatcher
+        )
         val cacheFile = File(mockContext.filesDir, APPLY_FILE_NAME)
         whenever(mockClient.apply(any(), any())).then {}
 
@@ -359,11 +365,13 @@ internal class ConfidenceFeatureProviderTests {
         )
 
         val testDispatcher = UnconfinedTestDispatcher(testScheduler)
-        val confidenceFeatureProvider = ConfidenceFeatureProvider.Builder(mockContext, "")
-            .cache(InMemoryCache())
-            .client(mockClient)
-            .dispatcher(testDispatcher)
-            .build()
+        val confidenceFeatureProvider = ConfidenceFeatureProvider.create(
+            context = mockContext,
+            clientSecret = "",
+            cache = InMemoryCache(),
+            client = mockClient,
+            dispatcher = testDispatcher
+        )
 
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(ResolveFlags(resolvedFlags, "token1"))
         whenever(mockClient.apply(any(), any())).then {}
@@ -411,11 +419,13 @@ internal class ConfidenceFeatureProviderTests {
         )
 
         val testDispatcher = UnconfinedTestDispatcher(testScheduler)
-        val confidenceFeatureProvider = ConfidenceFeatureProvider.Builder(mockContext, "")
-            .cache(InMemoryCache())
-            .client(mockClient)
-            .dispatcher(testDispatcher)
-            .build()
+        val confidenceFeatureProvider = ConfidenceFeatureProvider.create(
+            context = mockContext,
+            clientSecret = "",
+            cache = InMemoryCache(),
+            client = mockClient,
+            dispatcher = testDispatcher
+        )
 
         whenever(mockClient.apply(any(), any())).then {}
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(ResolveFlags(resolvedFlags, "token2"))
@@ -441,10 +451,12 @@ internal class ConfidenceFeatureProviderTests {
 
     @Test
     fun testMatchingRootObject() = runTest {
-        val confidenceFeatureProvider = ConfidenceFeatureProvider.Builder(mockContext, "")
-            .cache(InMemoryCache())
-            .client(mockClient)
-            .build()
+        val confidenceFeatureProvider = ConfidenceFeatureProvider.create(
+            context = mockContext,
+            clientSecret = "",
+            cache = InMemoryCache(),
+            client = mockClient
+        )
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(ResolveFlags(resolvedFlags, "token1"))
         runBlocking {
             confidenceFeatureProvider.initialize(MutableContext("foo"))
@@ -461,10 +473,12 @@ internal class ConfidenceFeatureProviderTests {
     @Test
     fun testStale() = runTest {
         val cache = InMemoryCache()
-        val confidenceFeatureProvider = ConfidenceFeatureProvider.Builder(mockContext, "")
-            .cache(cache)
-            .client(mockClient)
-            .build()
+        val confidenceFeatureProvider = ConfidenceFeatureProvider.create(
+            context = mockContext,
+            clientSecret = "",
+            cache = cache,
+            client = mockClient
+        )
 
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(ResolveFlags(resolvedFlags, "token1"))
 
@@ -528,16 +542,18 @@ internal class ConfidenceFeatureProviderTests {
     @Test
     fun testNonMatching() = runTest {
         val cache = InMemoryCache()
-        val confidenceFeatureProvider = ConfidenceFeatureProvider.Builder(mockContext, "")
-            .cache(cache)
-            .client(mockClient)
-            .build()
+        val confidenceFeatureProvider = ConfidenceFeatureProvider.create(
+            context = mockContext,
+            clientSecret = "",
+            cache = cache,
+            client = mockClient
+        )
 
         val resolvedNonMatchingFlags = Flags(
             listOf(
                 ResolvedFlag(
-                    "fdema-kotlin-flag-1",
-                    "",
+                    flag = "fdema-kotlin-flag-1",
+                    variant = "",
                     MutableStructure(mutableMapOf()),
                     ResolveReason.RESOLVE_REASON_NO_TREATMENT_MATCH
                 )
@@ -560,10 +576,12 @@ internal class ConfidenceFeatureProviderTests {
     @Test
     fun testFlagNotFound() = runTest {
         val cache = InMemoryCache()
-        val confidenceFeatureProvider = ConfidenceFeatureProvider.Builder(mockContext, "")
-            .cache(cache)
-            .client(mockClient)
-            .build()
+        val confidenceFeatureProvider = ConfidenceFeatureProvider.create(
+            context = mockContext,
+            clientSecret = "",
+            cache = cache,
+            client = mockClient
+        )
 
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(ResolveFlags(resolvedFlags, "token1"))
         // Simulate a case where the context in the cache is not synced with the evaluation's context
@@ -578,11 +596,12 @@ internal class ConfidenceFeatureProviderTests {
     @Test
     fun testErrorInNetwork() = runTest {
         val cache = InMemoryCache()
-        val confidenceFeatureProvider = ConfidenceFeatureProvider.Builder(mockContext, "")
-            .cache(cache)
-            .client(mockClient)
-            .build()
-
+        val confidenceFeatureProvider = ConfidenceFeatureProvider.create(
+            context = mockContext,
+            clientSecret = "",
+            cache = cache,
+            client = mockClient
+        )
         whenever(mockClient.resolve(eq(listOf()), any())).thenThrow(Error())
         runBlocking {
             confidenceFeatureProvider.initialize(MutableContext("user1"))
@@ -595,11 +614,12 @@ internal class ConfidenceFeatureProviderTests {
 
     @Test
     fun testValueNotFound() = runTest {
-        val confidenceFeatureProvider = ConfidenceFeatureProvider.Builder(mockContext, "")
-            .cache(InMemoryCache())
-            .client(mockClient)
-            .build()
-
+        val confidenceFeatureProvider = ConfidenceFeatureProvider.create(
+            context = mockContext,
+            clientSecret = "",
+            cache = InMemoryCache(),
+            client = mockClient
+        )
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(ResolveFlags(resolvedFlags, "token1"))
         runBlocking {
             confidenceFeatureProvider.initialize(MutableContext("user2"))
@@ -616,11 +636,12 @@ internal class ConfidenceFeatureProviderTests {
 
     @Test
     fun testValueNotFoundLongPath() = runTest {
-        val confidenceFeatureProvider = ConfidenceFeatureProvider.Builder(mockContext, "")
-            .cache(InMemoryCache())
-            .client(mockClient)
-            .build()
-
+        val confidenceFeatureProvider = ConfidenceFeatureProvider.create(
+            context = mockContext,
+            clientSecret = "",
+            cache = InMemoryCache(),
+            client = mockClient
+        )
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(ResolveFlags(resolvedFlags, "token1"))
         runBlocking {
             confidenceFeatureProvider.initialize(MutableContext("user2"))

--- a/Provider/src/test/java/dev/openfeature/contrib/providers/ConfidenceIntegrationTests.kt
+++ b/Provider/src/test/java/dev/openfeature/contrib/providers/ConfidenceIntegrationTests.kt
@@ -33,9 +33,7 @@ class ConfidenceIntegrationTests {
     fun testSimpleResolveInMemoryCache() {
         runBlocking {
             OpenFeatureAPI.setProvider(
-                ConfidenceFeatureProvider.Builder(mockContext, clientSecret)
-                    .cache(InMemoryCache())
-                    .build(),
+                ConfidenceFeatureProvider.create(mockContext, clientSecret, cache = InMemoryCache()),
                 MutableContext(
                     targetingKey = UUID.randomUUID().toString(),
                     attributes = mutableMapOf(
@@ -63,8 +61,7 @@ class ConfidenceIntegrationTests {
         assertEquals(0L, cacheFile.length())
         runBlocking {
             OpenFeatureAPI.setProvider(
-                ConfidenceFeatureProvider.Builder(mockContext, clientSecret)
-                    .build(),
+                ConfidenceFeatureProvider.create(mockContext, clientSecret),
                 MutableContext(
                     targetingKey = UUID.randomUUID().toString(),
                     attributes = mutableMapOf(

--- a/Provider/src/test/java/dev/openfeature/contrib/providers/StorageFileCacheTests.kt
+++ b/Provider/src/test/java/dev/openfeature/contrib/providers/StorageFileCacheTests.kt
@@ -59,12 +59,14 @@ class StorageFileCacheTests {
     @Test
     fun testOfflineScenarioLoadsStoredCache() = runTest {
         val mockClient: ConfidenceClient = mock()
-        val cache1 = StorageFileCache(mockContext)
+        val cache1 = StorageFileCache.create(mockContext)
         whenever(mockClient.resolve(eq(listOf()), any())).thenReturn(ResolveFlags(resolvedFlags, "token1"))
-        val provider1 = ConfidenceFeatureProvider.Builder(mockContext, "")
-            .client(mockClient)
-            .cache(cache1)
-            .build()
+        val provider1 = ConfidenceFeatureProvider.create(
+            context = mockContext,
+            clientSecret = "",
+            client = mockClient,
+            cache = cache1
+        )
         runBlocking {
             provider1.initialize(MutableContext(targetingKey = "user1"))
         }
@@ -72,11 +74,13 @@ class StorageFileCacheTests {
         // Simulate offline scenario
         whenever(mockClient.resolve(eq(listOf()), any())).thenThrow(Error())
         // Create new cache to force reading cache data from storage
-        val cache2 = StorageFileCache(mockContext)
-        val provider2 = ConfidenceFeatureProvider.Builder(mockContext, "")
-            .client(mockClient)
-            .cache(cache2)
-            .build()
+        val cache2 = StorageFileCache.create(mockContext)
+        val provider2 = ConfidenceFeatureProvider.create(
+            context = mockContext,
+            clientSecret = "",
+            client = mockClient,
+            cache = cache2
+        )
         val evalString = provider2.getStringEvaluation("fdema-kotlin-flag-1.mystring", "default", MutableContext("user1"))
         val evalBool = provider2.getBooleanEvaluation("fdema-kotlin-flag-1.myboolean", true, MutableContext("user1"))
         val evalInteger = provider2.getIntegerEvaluation("fdema-kotlin-flag-1.myinteger", 1, MutableContext("user1"))


### PR DESCRIPTION
* Remove the builder pattern from the provider
* Suspend the storage creation - read file


the Application will look like following:

```
viewModelScope.launch {
       // suspending
       val provider = ConfidenceFeatureProvider.create(
                context = app.applicationContext,
                clientSecret = "CLIENT_SECRET"
            )
       // suspending
            OpenFeatureAPI.setProvider(
                provider,
                initialContext = ctx
            )
            Log.d(TAG, "init took ${System.currentTimeMillis() - start} ms")
            refreshUi()
        }
```