### PR TITLE
add release pipeline and publishing using gpr

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,17 +12,6 @@ jobs:
   Tests:
     runs-on: ubuntu-latest
     steps:
-      # Fetch and publish the OpenFeature SDK locally, using remote "main" branch
-      # This should be removed once the SDK artifacts are openly deployed
-      - name: webfactory/ssh-agent
-        uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.SDK_REPO_PRIVATE_KEY }}
-      - name: Clone OpenFeature SDK dependency
-        run: git clone git@github.com:spotify/openfeature-kotlin-sdk.git
-      - name: Publish OpenFeature SDK locally
-        run: ./openfeature-kotlin-sdk/gradlew publishToMavenLocal -p openfeature-kotlin-sdk
-
       - name: Checkout
         uses: actions/checkout@v3
       - name: Run checks

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,54 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    name: Release Spotify Confidence Provider
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cache Gradle and wrapper
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - uses: actions/checkout@v1
+
+      - name: Set up JDK 12
+        uses: actions/setup-java@v1
+        with:
+          java-version: 12
+
+      - name: Grant Permission for Gradlew to Execute
+        run: chmod +x gradlew
+
+      - name: Build AAR ⚙️🛠
+        run: bash ./gradlew :provider:assemble
+
+      - name: Create Release ✅
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN_PUBLISH }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: true
+          prerelease: false
+
+      - name: Upload Confidence Provider AAR 🗳
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN_PUBLISH }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: Provider/build/outputs/aar/Provider-release.aar
+          asset_name: provider-release.aar
+          asset_content_type: application/aar

--- a/Provider/build.gradle.kts
+++ b/Provider/build.gradle.kts
@@ -1,4 +1,4 @@
-
+// ktlint-disable max-line-length
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
@@ -8,14 +8,14 @@ plugins {
 }
 
 object Versions {
-    const val openFeatureSDK = "0.0.1-SNAPSHOT"
+    const val openFeatureSDK = "v0.1.0"
     const val okHttp = "4.10.0"
     const val kotlinxSerialization = "1.5.1"
     const val coroutines = "1.7.1"
     const val junit = "4.13.2"
     const val kotlinMockito = "4.1.0"
     const val mockWebServer = "4.9.1"
-    const val providerVersion = "0.0.1-SNAPSHOT"
+    const val providerVersion = "0.1.0"
 }
 
 android {
@@ -39,23 +39,16 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
-    }
-
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-            withJavadocJar()
-        }
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 }
 
 dependencies {
-    api("dev.openfeature:kotlin-sdk:${Versions.openFeatureSDK}")
+    api("com.github.spotify:openfeature-kotlin-sdk:${Versions.openFeatureSDK}")
     implementation("com.squareup.okhttp3:okhttp:${Versions.okHttp}")
     implementation(
         "org.jetbrains.kotlinx:kotlinx-serialization-json:${Versions.kotlinxSerialization}"
@@ -67,15 +60,31 @@ dependencies {
     testImplementation("com.squareup.okhttp3:mockwebserver:${Versions.mockWebServer}")
 }
 
-publishing {
-    publications {
-        register<MavenPublication>("release") {
-            groupId = "dev.openfeature.contrib.providers"
-            artifactId = "confidence"
-            version = Versions.providerVersion
-            afterEvaluate {
+afterEvaluate {
+    publishing {
+        publications {
+            register<MavenPublication>("release") {
+                groupId = "dev.openfeature.contrib.providers"
+                artifactId = "confidence"
+                version = Versions.providerVersion
+
                 from(components["release"])
+                artifact(androidSourcesJar.get())
+
+                pom {
+                    name.set("SpotifyConfidenceProvider")
+                }
             }
         }
     }
+}
+
+val androidSourcesJar by tasks.registering(Jar::class) {
+    archiveClassifier.set("sources")
+    from(android.sourceSets.getByName("main").java.srcDirs)
+}
+
+// Assembling should be performed before publishing package
+tasks.named("publish") {
+    dependsOn("assemble")
 }

--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
 # OpenFeature Kotlin Confidence Provider
-
 Kotlin implementation of the Confidence feature provider, to be used in conjunction with the OpenFeature SDK.
 
 ## Usage
 
 ### Adding the package dependency
-
+[![](https://jitpack.io/v/spotify/confidence-openfeature-provider-kotlin.svg)](https://jitpack.io/#spotify/confidence-openfeature-provider-kotlin)
 Add the following dependency to your gradle file:
 ```
-implementation("dev.openfeature.contrib.providers:confidence:<LATEST>")
+:openfeature-kotlin-sdk:release-pipeline-SNAPSHOT
+implementation("com.github.spotify:confidence-openfeature-provider-kotlin:<VERSION>")
+for the latest version:
+implementation("com.github.spotify:confidence-openfeature-provider-kotlin")
+for using any branch and commit:
+implementation("com.github.spotify:confidence-openfeature-provider-kotlin:[BRANCH]-[SNAPSHOT/Version]")
+for using specific commit:
+implementation("com.github.spotify:confidence-openfeature-provider-kotlin:[COMMIT SHA]")
 ```
 
 Where `<LATEST>` is the most recent version of this SDK. Released versions can be found under "Releases" within this repository.

--- a/jitpack.yaml
+++ b/jitpack.yaml
@@ -1,0 +1,2 @@
+jdk:
+ - openjdk11

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,10 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         mavenLocal()
+
+        maven("https://jitpack.io")
     }
 }
+
 rootProject.name = "Provider"
 include(":Provider")


### PR DESCRIPTION
whenever we create and release a tag in the repo, there is a new release drafted and we can publish it.
rely on the openfeature sdk version 0.1.0 from releases.