### PR TITLE
Enable code minifying in provider and demo app

### DIFF
--- a/ConfidenceDemoApp/build.gradle.kts
+++ b/ConfidenceDemoApp/build.gradle.kts
@@ -53,7 +53,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/Provider/build.gradle.kts
+++ b/Provider/build.gradle.kts
@@ -31,7 +31,7 @@ android {
 
     buildTypes {
         getByName("release") {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"


### PR DESCRIPTION
In order to obfuscate the code in the release app, let's enable minifying in the provider and demo app.