### PR TITLE
[TEST] Manual testing duplications on slow network

### DIFF
--- a/Provider/src/main/java/dev/openfeature/contrib/providers/apply/FlagApplierWithRetries.kt
+++ b/Provider/src/main/java/dev/openfeature/contrib/providers/apply/FlagApplierWithRetries.kt
@@ -6,12 +6,8 @@ import dev.openfeature.contrib.providers.client.AppliedFlag
 import dev.openfeature.contrib.providers.client.ConfidenceClient
 import dev.openfeature.contrib.providers.client.serializers.UUIDSerializer
 import dev.openfeature.sdk.DateSerializer
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.SendChannel
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
@@ -119,7 +115,14 @@ class FlagApplierWithRetries(
             // TODO chunk size 20 is an arbitrary value, replace with appropriate size
             appliedFlagsKeyed.chunked(CHUNK_SIZE).forEach { appliedFlagsKeyedChunk ->
                 coroutineScope.launch(coroutineExceptionHandler) {
+                    println(">> Network starts")
                     client.apply(appliedFlagsKeyedChunk, token)
+                    delay(7000)
+                    println(">> Network returns")
+                    // TODO delay vs. sleep: how to really emulate slow network in unit tests?
+//                  //  delay(5000)
+                    // Thread.sleep(5000)
+                    println(">> [✉️] for $appliedFlagsKeyedChunk")
                     sendChannel.send(FlagApplierBatchProcessedInput(token, appliedFlagsKeyedChunk))
                 }
             }

--- a/Provider/src/test/java/dev/openfeature/contrib/providers/ConfidenceIntegrationTests.kt
+++ b/Provider/src/test/java/dev/openfeature/contrib/providers/ConfidenceIntegrationTests.kt
@@ -47,12 +47,14 @@ class ConfidenceIntegrationTests {
             )
         }
         val intDetails = OpenFeatureAPI.getClient().getIntegerDetails("test-flag-1.my-integer", 0)
+        val test = OpenFeatureAPI.getClient().getBooleanDetails("test-flag-4.enabled", false)
         assertNull(intDetails.errorCode)
         assertNull(intDetails.errorMessage)
         assertNotNull(intDetails.value)
         assertNotEquals(0, intDetails.value)
         assertEquals(Reason.TARGETING_MATCH.name, intDetails.reason)
         assertNotNull(intDetails.variant)
+        Thread.sleep(20000)
     }
 
     @Test


### PR DESCRIPTION
What we want to test is a series of apply events generated while the network is slow, and make sure the Applier logic doesn't generate unwanted duplicates and the retries work as intended

Output from `testSimpleResolveInMemoryCache`:
```
>> APPLY ENTERS, processor gets new apply event
>> APPLY RETURNS, application code can continue now...
>> Wrote in writeRequestChannel!
>> APPLY ENTERS, processor gets new apply event
>> APPLY RETURNS, application code can continue now...
>> Entered writeRequestChannel
>> Exits writeRequestChannel
>> Network starts
>> Entered writeRequestChannel
>> Wrote in writeRequestChannel!
>> Exits writeRequestChannel
>> Network starts
>> Network returns
>> Network returns
>> [✉️] for [AppliedFlag(flag=test-flag-4, applyTime=Fri Jul 28 12:33:06 CEST 2023), AppliedFlag(flag=test-flag-1, applyTime=Fri Jul 28 12:33:06 CEST 2023)]
>> [✉️] for [AppliedFlag(flag=test-flag-1, applyTime=Fri Jul 28 12:33:06 CEST 2023)]
>> Entered dataSentChannel
>> Exits dataSentChannel
>> Entered dataSentChannel
>> Exits dataSentChannel
```