### PR TITLE
feat: Add observable error events in case of failed remote resolve

### DIFF
--- a/Provider/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.kt
+++ b/Provider/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.kt
@@ -43,8 +43,9 @@ class ConfidenceFeatureProvider private constructor(
 
     private val coroutineScope = CoroutineScope(job + dispatcher)
     private val networkExceptionHandler by lazy {
-        CoroutineExceptionHandler { _, _ ->
+        CoroutineExceptionHandler { _, t ->
             // network failed, provider is ready but with default/cache values
+            eventHandler.publish(OpenFeatureEvents.ProviderError(t))
             eventHandler.publish(OpenFeatureEvents.ProviderReady)
         }
     }


### PR DESCRIPTION
Cross-posting the latest OF events/state proposal [here](https://openfeature.dev/blog#context-reconciliation), for reference:

<img width="500" alt="Screenshot 2024-03-14 at 15 18 04" src="https://github.com/spotify/confidence-openfeature-provider-kotlin/assets/7601824/829b9de4-d7bd-4317-a79b-3ef5620cead5">


The transition introduced in the PR is allowed:
```
NOT_READY -> initialize() -> ERROR -> READY
```

I am not particularly fond of adding a short ERROR state before moving to READY, just so we can emit the ERROR event for the user to observe. I wonder if we could add some WARNING or LOG event type in the OF layer, that doesn't cause state transitions but allows to communicate internals to the user.

However, this could be a stop-gap solution for now