### PR TITLE
fix: Release please increase depth

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,7 @@
             "bump-patch-for-minor-pre-major": true,
             "versioning": "default",
             "include-v-in-tag": false,
+            "commit-search-depth": 1000,
             "extra-files": [
                 "README.md",
                 "build.gradle.kts"


### PR DESCRIPTION
<img width="1274" alt="Screenshot 2024-05-07 at 17 12 54" src="https://github.com/spotify/confidence-sdk-android/assets/7601824/5d3fbe2c-e5b3-4c87-840b-dbe8f984faf5">

The error in CI shows up related to some query failing, and I believe the 500 limit a few lines up might be the problem (since we haven't released in a while, the depth of our queries might have increased)