### PR TITLE
fix: Add version/build to context

### DIFF
--- a/Confidence/src/main/java/com/spotify/confidence/AndroidLifecycleEventProducer.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/AndroidLifecycleEventProducer.kt
@@ -128,11 +128,6 @@ class AndroidLifecycleEventProducer(
         val currentVersion = ConfidenceValue.String(packageInfo?.versionName ?: "")
         val currentBuild = ConfidenceValue.String(packageInfo?.getVersionCode().toString() ?: "")
 
-        // Get the previous recorded version.
-        val previousVersion = sharedPreferences
-            .getString(APP_VERSION, null)
-            ?.let(ConfidenceValue::String)
-
         val previousBuild: ConfidenceValue.String? = sharedPreferences
             .getString(APP_BUILD, null)
             ?.let(ConfidenceValue::String)
@@ -141,14 +136,12 @@ class AndroidLifecycleEventProducer(
 
         // Check and track Application Installed or Application Updated.
         if (previousBuild == null && legacyPreviousBuild == null) {
-            val message = mapOf("version" to currentVersion, "build" to currentBuild)
+            val message = mapOf(APP_VERSION_KEY to currentVersion, APP_BUILD_KEY to currentBuild)
             coroutineScope.launch { eventsFlow.emit(Event(APP_INSTALLED_EVENT, message)) }
         } else if (currentBuild != previousBuild) {
             val message = mapOf(
-                "version" to currentVersion,
-                "build" to currentBuild,
-                "previous_version" to (previousVersion ?: ConfidenceValue.String("")),
-                "previous_build" to (previousBuild ?: ConfidenceValue.String(""))
+                APP_VERSION_KEY to currentVersion,
+                APP_BUILD_KEY to currentBuild
             )
             coroutineScope.launch { eventsFlow.emit(Event(APP_UPDATED_EVENT, message)) }
         }
@@ -159,7 +152,7 @@ class AndroidLifecycleEventProducer(
         }
 
         coroutineScope.launch {
-            val message = mapOf("version" to currentVersion, "build" to currentBuild)
+            val message = mapOf(APP_VERSION_KEY to currentVersion, APP_BUILD_KEY to currentBuild)
             eventsFlow.emit(Event(APP_LAUNCHED_EVENT, message))
         }
     }
@@ -184,6 +177,8 @@ class AndroidLifecycleEventProducer(
 
         // Context keys
         private const val IS_FOREGROUND_KEY = "is_foreground"
+        private const val APP_VERSION_KEY = "app_version"
+        private const val APP_BUILD_KEY = "app_build"
 
         // Event keys
         private const val APP_INSTALLED_EVENT = "app-installed"

--- a/Confidence/src/main/java/com/spotify/confidence/AndroidLifecycleEventProducer.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/AndroidLifecycleEventProducer.kt
@@ -70,6 +70,7 @@ class AndroidLifecycleEventProducer(
         updateContext(mapOf(key to value))
     }
 
+    @Synchronized
     private fun updateContext(map: Map<String, ConfidenceValue>) {
         val map = contextFlow.value.toMutableMap()
         map += map

--- a/Confidence/src/main/java/com/spotify/confidence/AndroidLifecycleEventProducer.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/AndroidLifecycleEventProducer.kt
@@ -151,9 +151,9 @@ class AndroidLifecycleEventProducer(
 
         // Check and track Application Installed or Application Updated.
         if (previousBuild == null && legacyPreviousBuild == null) {
-            coroutineScope.launch { eventsFlow.emit(Event(APP_INSTALLED_EVENT, mapOf())) }
+            coroutineScope.launch { eventsFlow.emit(Event(APP_INSTALLED_EVENT, mapOf(), true)) }
         } else if (currentBuild != previousBuild) {
-            coroutineScope.launch { eventsFlow.emit(Event(APP_UPDATED_EVENT, mapOf())) }
+            coroutineScope.launch { eventsFlow.emit(Event(APP_UPDATED_EVENT, mapOf(), true)) }
         }
 
         coroutineScope.launch {
@@ -162,7 +162,7 @@ class AndroidLifecycleEventProducer(
         }
 
         coroutineScope.launch {
-            eventsFlow.emit(Event(APP_LAUNCHED_EVENT, mapOf()))
+            eventsFlow.emit(Event(APP_LAUNCHED_EVENT, mapOf(), true))
         }
     }
 

--- a/Confidence/src/main/java/com/spotify/confidence/AndroidLifecycleEventProducer.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/AndroidLifecycleEventProducer.kt
@@ -72,9 +72,9 @@ class AndroidLifecycleEventProducer(
 
     @Synchronized
     private fun updateContext(map: Map<String, ConfidenceValue>) {
-        val map = contextFlow.value.toMutableMap()
-        map += map
-        contextFlow.value = map
+        val context = contextFlow.value.toMutableMap()
+        context += map
+        contextFlow.value = context
     }
 
     override fun onActivityStarted(activity: Activity) {

--- a/Confidence/src/main/java/com/spotify/confidence/AndroidLifecycleEventProducer.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/AndroidLifecycleEventProducer.kt
@@ -59,13 +59,21 @@ class AndroidLifecycleEventProducer(
     }
 
     override fun onStart(owner: LifecycleOwner) {
-        contextFlow.value =
-            mapOf(IS_FOREGROUND_KEY to ConfidenceValue.Boolean(true))
+        updateContext(IS_FOREGROUND_KEY, ConfidenceValue.Boolean(true))
     }
 
     override fun onStop(owner: LifecycleOwner) {
-        contextFlow.value =
-            mapOf(IS_FOREGROUND_KEY to ConfidenceValue.Boolean(false))
+        updateContext(IS_FOREGROUND_KEY, ConfidenceValue.Boolean(false))
+    }
+
+    private fun updateContext(key: String, value: ConfidenceValue) {
+        updateContext(mapOf(key to value))
+    }
+
+    private fun updateContext(map: Map<String, ConfidenceValue>) {
+        val map = contextFlow.value.toMutableMap()
+        map += map
+        contextFlow.value = map
     }
 
     override fun onActivityStarted(activity: Activity) {
@@ -128,10 +136,11 @@ class AndroidLifecycleEventProducer(
         val currentVersion = ConfidenceValue.String(packageInfo?.versionName ?: "")
         val currentBuild = ConfidenceValue.String(packageInfo?.getVersionCode().toString() ?: "")
 
-        contextFlow.value =
-            mapOf(APP_VERSION_KEY to currentVersion)
-        contextFlow.value =
-            mapOf(APP_BUILD_KEY to currentBuild)
+        val addedContext = mapOf(
+            APP_VERSION_KEY to currentVersion,
+            APP_BUILD_KEY to currentBuild
+        )
+        updateContext(addedContext)
 
         val previousBuild: ConfidenceValue.String? = sharedPreferences
             .getString(APP_BUILD, null)

--- a/Confidence/src/main/java/com/spotify/confidence/AndroidLifecycleEventProducer.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/AndroidLifecycleEventProducer.kt
@@ -128,6 +128,11 @@ class AndroidLifecycleEventProducer(
         val currentVersion = ConfidenceValue.String(packageInfo?.versionName ?: "")
         val currentBuild = ConfidenceValue.String(packageInfo?.getVersionCode().toString() ?: "")
 
+        contextFlow.value =
+            mapOf(APP_VERSION_KEY to currentVersion)
+        contextFlow.value =
+            mapOf(APP_BUILD_KEY to currentBuild)
+
         val previousBuild: ConfidenceValue.String? = sharedPreferences
             .getString(APP_BUILD, null)
             ?.let(ConfidenceValue::String)
@@ -136,14 +141,9 @@ class AndroidLifecycleEventProducer(
 
         // Check and track Application Installed or Application Updated.
         if (previousBuild == null && legacyPreviousBuild == null) {
-            val message = mapOf(APP_VERSION_KEY to currentVersion, APP_BUILD_KEY to currentBuild)
-            coroutineScope.launch { eventsFlow.emit(Event(APP_INSTALLED_EVENT, message)) }
+            coroutineScope.launch { eventsFlow.emit(Event(APP_INSTALLED_EVENT, mapOf())) }
         } else if (currentBuild != previousBuild) {
-            val message = mapOf(
-                APP_VERSION_KEY to currentVersion,
-                APP_BUILD_KEY to currentBuild
-            )
-            coroutineScope.launch { eventsFlow.emit(Event(APP_UPDATED_EVENT, message)) }
+            coroutineScope.launch { eventsFlow.emit(Event(APP_UPDATED_EVENT, mapOf())) }
         }
 
         coroutineScope.launch {
@@ -152,8 +152,7 @@ class AndroidLifecycleEventProducer(
         }
 
         coroutineScope.launch {
-            val message = mapOf(APP_VERSION_KEY to currentVersion, APP_BUILD_KEY to currentBuild)
-            eventsFlow.emit(Event(APP_LAUNCHED_EVENT, message))
+            eventsFlow.emit(Event(APP_LAUNCHED_EVENT, mapOf()))
         }
     }
 

--- a/Confidence/src/main/java/com/spotify/confidence/Confidence.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/Confidence.kt
@@ -202,6 +202,9 @@ class Confidence internal constructor(
                         event.message,
                         getContext()
                     )
+                    if (event.shouldFlush) {
+                        eventSenderEngine.flush()
+                    }
                 }
         }
 

--- a/Confidence/src/main/java/com/spotify/confidence/EventProducer.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/EventProducer.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 data class Event(
     val name: String,
     val message: Map<String, ConfidenceValue>,
-    var shouldFlush: Boolean = false
+    val shouldFlush: Boolean = false
 )
 
 interface EventProducer {

--- a/Confidence/src/main/java/com/spotify/confidence/EventProducer.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/EventProducer.kt
@@ -4,7 +4,8 @@ import kotlinx.coroutines.flow.Flow
 
 data class Event(
     val name: String,
-    val message: Map<String, ConfidenceValue>
+    val message: Map<String, ConfidenceValue>,
+    var shouldFlush: Boolean = false
 )
 
 interface EventProducer {


### PR DESCRIPTION
`previous_version` and `previous_build` are not available in iOS: removing for consistency.
Also changing the context keys for version and build for consistency: https://github.com/spotify/confidence-sdk-swift/pull/127