### PR TITLE
refactor: Add ConfidenceForOF proxy for safe init

### DIFF
--- a/Provider/src/main/java/com/spotify/confidence/openfeature/ConfidenceFeatureProvider.kt
+++ b/Provider/src/main/java/com/spotify/confidence/openfeature/ConfidenceFeatureProvider.kt
@@ -145,8 +145,10 @@ class ConfidenceFeatureProvider private constructor(
             throw OpenFeatureError.FlagNotFoundError(e.flag)
         }
     }
+
     companion object {
         private class ConfidenceMetadata(override var name: String? = "confidence") : ProviderMetadata
+        class ConfidenceForOpenFeature internal constructor(val confidence: Confidence)
 
         fun createConfidence(
             context: Context,
@@ -154,20 +156,22 @@ class ConfidenceFeatureProvider private constructor(
             initialContext: Map<String, ConfidenceValue> = mapOf(),
             region: ConfidenceRegion = ConfidenceRegion.GLOBAL,
             dispatcher: CoroutineDispatcher = Dispatchers.IO
-        ): Confidence {
-            return ConfidenceFactory.create(
-                context,
-                clientSecret,
-                sdk = SdkMetadata("SDK_ID_KOTLIN_PROVIDER", BuildConfig.SDK_VERSION),
-                initialContext = initialContext,
-                region = region,
-                dispatcher = dispatcher
+        ): ConfidenceForOpenFeature {
+            return ConfidenceForOpenFeature(
+                ConfidenceFactory.create(
+                    context,
+                    clientSecret,
+                    sdk = SdkMetadata("SDK_ID_KOTLIN_PROVIDER", BuildConfig.SDK_VERSION),
+                    initialContext = initialContext,
+                    region = region,
+                    dispatcher = dispatcher
+                )
             )
         }
 
         @Suppress("LongParameterList")
         fun create(
-            confidence: Confidence,
+            confidenceForOF: ConfidenceForOpenFeature,
             initialisationStrategy: InitialisationStrategy = InitialisationStrategy.FetchAndActivate,
             hooks: List<Hook<*>> = listOf(),
             metadata: ProviderMetadata = ConfidenceMetadata(),
@@ -179,7 +183,7 @@ class ConfidenceFeatureProvider private constructor(
                 metadata = metadata,
                 initialisationStrategy = initialisationStrategy,
                 eventHandler = eventHandler,
-                confidence = confidence,
+                confidence = confidenceForOF.confidence,
                 dispatcher = dispatcher
             )
         }

--- a/Provider/src/test/java/com/spotify/confidence/openfeature/ConfidenceIntegrationTests.kt
+++ b/Provider/src/test/java/com/spotify/confidence/openfeature/ConfidenceIntegrationTests.kt
@@ -45,10 +45,12 @@ class ConfidenceIntegrationTests {
         val eventsHandler = EventHandler(Dispatchers.IO).apply {
             publish(OpenFeatureEvents.ProviderStale)
         }
-        val mockConfidence = ConfidenceFactory.create(mockContext, clientSecret)
+        val mockConfidence = ConfidenceFeatureProvider.Companion.ConfidenceForOpenFeature(
+            ConfidenceFactory.create(mockContext, clientSecret)
+        )
         OpenFeatureAPI.setProvider(
             ConfidenceFeatureProvider.create(
-                confidence = mockConfidence,
+                confidenceForOF = mockConfidence,
                 initialisationStrategy = InitialisationStrategy.FetchAndActivate,
                 eventHandler = eventsHandler
             ),
@@ -87,10 +89,12 @@ class ConfidenceIntegrationTests {
         }
         val cacheFile = File(mockContext.filesDir, FLAGS_FILE_NAME)
         assertEquals(0L, cacheFile.length())
-        val mockConfidence = ConfidenceFactory.create(mockContext, clientSecret)
+        val mockConfidence = ConfidenceFeatureProvider.Companion.ConfidenceForOpenFeature(
+            ConfidenceFactory.create(mockContext, clientSecret)
+        )
         OpenFeatureAPI.setProvider(
             ConfidenceFeatureProvider.create(
-                confidence = mockConfidence,
+                confidenceForOF = mockConfidence,
                 eventHandler = eventsHandler
             ),
             ImmutableContext(


### PR DESCRIPTION
Replicating https://github.com/spotify/confidence-sdk-swift/pull/141