### PR TITLE
feat: expose convert value to json

### DIFF
--- a/Confidence/src/main/java/com/spotify/confidence/ConfidenceValue.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/ConfidenceValue.kt
@@ -4,6 +4,7 @@ import com.spotify.confidence.serializers.ConfidenceValueSerializer
 import com.spotify.confidence.serializers.DateSerializer
 import com.spotify.confidence.serializers.DateTimeSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
 @Serializable(ConfidenceValueSerializer::class)
 sealed interface ConfidenceValue {
@@ -52,3 +53,6 @@ sealed interface ConfidenceValue {
             List(list.map(ConfidenceValue::Timestamp))
     }
 }
+
+fun ConfidenceValue.Struct.toNetworkJson() =
+    Json.encodeToString(NetworkConfidenceValueSerializer, this)


### PR DESCRIPTION
expose the json representation of a confidence struct.
useful for where it's needed like Flutter without having to depend on kotlinx serialization in the flutter sdk.