### PR TITLE
fix: guard possible changes in serialization

### DIFF
--- a/Confidence/src/main/java/com/spotify/confidence/cache/FileDiskStorage.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/cache/FileDiskStorage.kt
@@ -10,7 +10,7 @@ import java.io.File
 internal const val FLAGS_FILE_NAME = "confidence_flags_cache.json"
 internal const val APPLY_FILE_NAME = "confidence_apply_cache.json"
 
-internal class FileDiskStorage private constructor(
+internal class FileDiskStorage internal constructor(
     private val flagsFile: File,
     private val applyFile: File
 ) : DiskStorage {
@@ -33,7 +33,12 @@ internal class FileDiskStorage private constructor(
         return if (fileText.isEmpty()) {
             mutableMapOf()
         } else {
-            Json.decodeFromString(fileText)
+            try {
+                Json.decodeFromString(fileText)
+            } catch (e: Throwable) {
+                applyFile.delete()
+                mutableMapOf()
+            }
         }
     }
 
@@ -47,7 +52,12 @@ internal class FileDiskStorage private constructor(
         return if (fileText.isEmpty()) {
             FlagResolution.EMPTY
         } else {
-            Json.decodeFromString(fileText)
+            try {
+                Json.decodeFromString(fileText)
+            } catch (e: Throwable) {
+                clear()
+                FlagResolution.EMPTY
+            }
         }
     }
 

--- a/Confidence/src/test/java/com/spotify/confidence/FileDiskStorageTest.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/FileDiskStorageTest.kt
@@ -1,0 +1,68 @@
+package com.spotify.confidence
+
+import com.spotify.confidence.apply.ApplyInstance
+import com.spotify.confidence.apply.EventStatus
+import com.spotify.confidence.cache.FileDiskStorage
+import com.spotify.confidence.client.ConfidenceValueMap
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+import java.util.Date
+
+class FileDiskStorageTest {
+    private lateinit var diskStorage: FileDiskStorage
+    private lateinit var flagsFile: File
+    private lateinit var applyFile: File
+
+    val badFile = "{\"context\":{\"name\":\"emu64a\",\"version\":\"1.0\",\"density\":2.625,\"height\":1857.0,\"width\":1080,\"namespace\":\"com.example.confidencedemoapp\",\"build\":\"1\",\"manufacturer\":\"Google\",\"model\":\"sdk_gphone64_arm64\",\"type\":\"android\",\"targeting_key\":\"a98a4291-53b0-49d9-bae8-73d3f5da2070\"},\"flags\":[{\"flag\":\"hatten\",\"variant\":\"\",\"reason\":\"RESOLVE_REASON_NO_SEGMENT_MATCH\"}],\"resolveToken\":\"meh\"}"
+    val badApply = "{\"apply\":{\"apply\":\"apply\"}"
+
+    @Before
+    fun setup() {
+        flagsFile = Files.createTempFile("flags", ".txt").toFile()
+        applyFile = Files.createTempFile("apply", ".txt").toFile()
+        diskStorage = FileDiskStorage(flagsFile, applyFile)
+    }
+
+    @Test
+    fun handleCrashingDeserializationForFlags() {
+        flagsFile.writeText(badFile)
+        val read = diskStorage.read()
+        Assert.assertEquals(FlagResolution.EMPTY, read)
+        Assert.assertFalse(flagsFile.exists())
+
+        diskStorage.store(FlagResolution(mapOf("name" to ConfidenceValue.String("emu64a")), listOf(), "abcd"))
+        Assert.assertTrue(flagsFile.exists())
+    }
+
+    @Test
+    fun handleCrashingDeserializationForApplyData() {
+        applyFile.writeText(badApply)
+        val read = diskStorage.readApplyData()
+        Assert.assertEquals(emptyMap<String, MutableMap<String, ApplyInstance>>(), read)
+
+        diskStorage.writeApplyData(mutableMapOf("apply" to mutableMapOf("apply" to ApplyInstance(Date(), EventStatus.CREATED))))
+        Assert.assertTrue(applyFile.exists())
+    }
+
+    @Test
+    fun readEmptyFlagsFile() {
+        val read = diskStorage.read()
+        Assert.assertEquals(FlagResolution.EMPTY, read)
+    }
+
+    @Test
+    fun readEmptyApplyFile() {
+        val read = diskStorage.readApplyData()
+        Assert.assertEquals(emptyMap<String, MutableMap<String, ApplyInstance>>(), read)
+    }
+
+    @Test
+    fun testStoreFlagResolution() {
+        diskStorage.store(FlagResolution.EMPTY)
+        val read = diskStorage.read()
+        Assert.assertEquals(FlagResolution.EMPTY, read)
+    }
+}


### PR DESCRIPTION
This PR fixes app crash after breaking changes to how we serialize storing flag and apply data. If the app can't read the storage (format can't be read), it wipes the file and fetches latest flags and applies in case of sticky assignment.