### PR TITLE
fix!: suspending context modifier functions

### DIFF
--- a/Confidence/api/Confidence.api
+++ b/Confidence/api/Confidence.api
@@ -40,13 +40,13 @@ public final class com/spotify/confidence/Confidence : com/spotify/confidence/Co
 	public final fun getFlag (Ljava/lang/String;Ljava/lang/Object;)Lcom/spotify/confidence/Evaluation;
 	public final fun getValue (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun isStorageEmpty ()Z
-	public fun putContext (Ljava/lang/String;Lcom/spotify/confidence/ConfidenceValue;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun putContext (Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun putContext (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun putContextSync (Ljava/lang/String;Lcom/spotify/confidence/ConfidenceValue;)V
-	public fun putContextSync (Ljava/util/Map;)V
-	public fun removeContext (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun removeContextSync (Ljava/lang/String;)V
+	public fun putContext (Ljava/lang/String;Lcom/spotify/confidence/ConfidenceValue;)V
+	public fun putContext (Ljava/util/Map;)V
+	public fun putContextAndAwait (Ljava/lang/String;Lcom/spotify/confidence/ConfidenceValue;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun putContextAndAwait (Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun putContextAndAwait (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun removeContext (Ljava/lang/String;)V
+	public fun removeContextAndAwait (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun stop ()V
 	public fun track (Lcom/spotify/confidence/EventProducer;)V
 	public fun track (Ljava/lang/String;Ljava/util/Map;)V
@@ -382,12 +382,12 @@ public final class com/spotify/confidence/ConfidenceValueKt {
 }
 
 public abstract interface class com/spotify/confidence/Contextual : com/spotify/confidence/ConfidenceContextProvider {
-	public abstract fun putContext (Ljava/lang/String;Lcom/spotify/confidence/ConfidenceValue;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun putContext (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun putContextSync (Ljava/lang/String;Lcom/spotify/confidence/ConfidenceValue;)V
-	public abstract fun putContextSync (Ljava/util/Map;)V
-	public abstract fun removeContext (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun removeContextSync (Ljava/lang/String;)V
+	public abstract fun putContext (Ljava/lang/String;Lcom/spotify/confidence/ConfidenceValue;)V
+	public abstract fun putContext (Ljava/util/Map;)V
+	public abstract fun putContextAndAwait (Ljava/lang/String;Lcom/spotify/confidence/ConfidenceValue;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun putContextAndAwait (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun removeContext (Ljava/lang/String;)V
+	public abstract fun removeContextAndAwait (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withContext (Ljava/util/Map;)Lcom/spotify/confidence/Contextual;
 }
 

--- a/Confidence/api/Confidence.api
+++ b/Confidence/api/Confidence.api
@@ -40,10 +40,13 @@ public final class com/spotify/confidence/Confidence : com/spotify/confidence/Co
 	public final fun getFlag (Ljava/lang/String;Ljava/lang/Object;)Lcom/spotify/confidence/Evaluation;
 	public final fun getValue (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun isStorageEmpty ()Z
-	public fun putContext (Ljava/lang/String;Lcom/spotify/confidence/ConfidenceValue;)V
-	public fun putContext (Ljava/util/Map;)V
-	public final fun putContext (Ljava/util/Map;Ljava/util/List;)V
-	public fun removeContext (Ljava/lang/String;)V
+	public fun putContext (Ljava/lang/String;Lcom/spotify/confidence/ConfidenceValue;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun putContext (Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun putContext (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun putContextSync (Ljava/lang/String;Lcom/spotify/confidence/ConfidenceValue;)V
+	public fun putContextSync (Ljava/util/Map;)V
+	public fun removeContext (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun removeContextSync (Ljava/lang/String;)V
 	public fun stop ()V
 	public fun track (Lcom/spotify/confidence/EventProducer;)V
 	public fun track (Ljava/lang/String;Ljava/util/Map;)V
@@ -102,8 +105,8 @@ public final class com/spotify/confidence/ConfidenceError$ParseError : java/lang
 
 public final class com/spotify/confidence/ConfidenceFactory {
 	public static final field INSTANCE Lcom/spotify/confidence/ConfidenceFactory;
-	public final fun create (Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Lcom/spotify/confidence/ConfidenceRegion;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/spotify/confidence/LoggingLevel;)Lcom/spotify/confidence/Confidence;
-	public static synthetic fun create$default (Lcom/spotify/confidence/ConfidenceFactory;Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Lcom/spotify/confidence/ConfidenceRegion;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/spotify/confidence/LoggingLevel;ILjava/lang/Object;)Lcom/spotify/confidence/Confidence;
+	public final fun create (Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Lcom/spotify/confidence/ConfidenceRegion;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/spotify/confidence/LoggingLevel;J)Lcom/spotify/confidence/Confidence;
+	public static synthetic fun create$default (Lcom/spotify/confidence/ConfidenceFactory;Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Lcom/spotify/confidence/ConfidenceRegion;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/spotify/confidence/LoggingLevel;JILjava/lang/Object;)Lcom/spotify/confidence/Confidence;
 }
 
 public final class com/spotify/confidence/ConfidenceFlagEvaluationKt {
@@ -379,9 +382,12 @@ public final class com/spotify/confidence/ConfidenceValueKt {
 }
 
 public abstract interface class com/spotify/confidence/Contextual : com/spotify/confidence/ConfidenceContextProvider {
-	public abstract fun putContext (Ljava/lang/String;Lcom/spotify/confidence/ConfidenceValue;)V
-	public abstract fun putContext (Ljava/util/Map;)V
-	public abstract fun removeContext (Ljava/lang/String;)V
+	public abstract fun putContext (Ljava/lang/String;Lcom/spotify/confidence/ConfidenceValue;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun putContext (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun putContextSync (Ljava/lang/String;Lcom/spotify/confidence/ConfidenceValue;)V
+	public abstract fun putContextSync (Ljava/util/Map;)V
+	public abstract fun removeContext (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun removeContextSync (Ljava/lang/String;)V
 	public abstract fun withContext (Ljava/util/Map;)Lcom/spotify/confidence/Contextual;
 }
 

--- a/Confidence/src/main/java/com/spotify/confidence/Confidence.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/Confidence.kt
@@ -110,15 +110,15 @@ class Confidence internal constructor(
         return eval
     }
 
-    override fun putContextSync(key: String, value: ConfidenceValue) {
+    override fun putContext(key: String, value: ConfidenceValue) {
         val map = contextMap.value.toMutableMap()
         map[key] = value
         contextMap.value = map
         debugLogger?.logContext("PutContext", contextMap.value)
     }
 
-    override suspend fun putContext(key: String, value: ConfidenceValue) {
-        putContextSync(key, value)
+    override suspend fun putContextAndAwait(key: String, value: ConfidenceValue) {
+        putContext(key, value)
         triggerContextChange()
     }
 
@@ -129,15 +129,15 @@ class Confidence internal constructor(
         }
     }
 
-    override fun putContextSync(context: Map<String, ConfidenceValue>) {
+    override fun putContext(context: Map<String, ConfidenceValue>) {
         val map = contextMap.value.toMutableMap()
         map += context
         contextMap.value = map
         debugLogger?.logContext("PutContext", contextMap.value)
     }
 
-    override suspend fun putContext(context: Map<String, ConfidenceValue>) {
-        putContextSync(context)
+    override suspend fun putContextAndAwait(context: Map<String, ConfidenceValue>) {
+        putContext(context)
         triggerContextChange()
     }
 
@@ -151,7 +151,7 @@ class Confidence internal constructor(
      * @param context context to add.
      * @param removedKeys key to remove from context.
      */
-    suspend fun putContext(context: Map<String, ConfidenceValue>, removedKeys: List<String>) {
+    suspend fun putContextAndAwait(context: Map<String, ConfidenceValue>, removedKeys: List<String>) {
         val map = contextMap.value.toMutableMap()
         map += context
         for (key in removedKeys) {
@@ -163,7 +163,7 @@ class Confidence internal constructor(
         triggerContextChange()
     }
 
-    override fun removeContextSync(key: String) {
+    override fun removeContext(key: String) {
         val map = contextMap.value.toMutableMap()
         map.remove(key)
         removedKeys.add(key)
@@ -171,8 +171,8 @@ class Confidence internal constructor(
         debugLogger?.logContext("RemoveContext", contextMap.value)
     }
 
-    override suspend fun removeContext(key: String) {
-        removeContextSync(key)
+    override suspend fun removeContextAndAwait(key: String) {
+        removeContext(key)
         triggerContextChange()
     }
 
@@ -194,7 +194,7 @@ class Confidence internal constructor(
         region,
         debugLogger
     ).also {
-        it.putContextSync(context)
+        it.putContext(context)
     }
 
     override fun track(
@@ -365,6 +365,7 @@ object ConfidenceFactory {
     }
 }
 
+@Deprecated("Use putContextAndAwait(context) instead", replaceWith = ReplaceWith("putContextAndAwait(context)"))
 suspend fun Confidence.awaitPutContext(context: Map<String, ConfidenceValue>) {
     putContext(context)
     awaitReconciliation()

--- a/Confidence/src/main/java/com/spotify/confidence/ConfidenceContext.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/ConfidenceContext.kt
@@ -17,40 +17,40 @@ interface Contextual : ConfidenceContextProvider {
     fun withContext(context: Map<String, ConfidenceValue>): Contextual
 
     /**
+     * Add entry to context and await the reconciliation
+     * @param context context to add.
+     */
+    suspend fun putContextAndAwait(context: Map<String, ConfidenceValue>)
+
+    /**
+     * Add entry to context and await the reconciliation
+     * @param key key of the entry.
+     * @param value value of the entry.
+     */
+    suspend fun putContextAndAwait(key: String, value: ConfidenceValue)
+
+    /**
+     * Remove entry from context and await the reconciliation
+     * @param key key of the context to be removed.
+     */
+    suspend fun removeContextAndAwait(key: String)
+
+    /**
      * Add entry to context
      * @param context context to add.
      */
-    suspend fun putContext(context: Map<String, ConfidenceValue>)
+    fun putContext(context: Map<String, ConfidenceValue>)
 
     /**
      * Add entry to context
      * @param key key of the entry.
      * @param value value of the entry.
      */
-    suspend fun putContext(key: String, value: ConfidenceValue)
+    fun putContext(key: String, value: ConfidenceValue)
 
     /**
      * Remove entry from context
      * @param key key of the context to be removed.
      */
-    suspend fun removeContext(key: String)
-
-    /**
-     * Add entry to context
-     * @param context context to add.
-     */
-    fun putContextSync(context: Map<String, ConfidenceValue>)
-
-    /**
-     * Add entry to context
-     * @param key key of the entry.
-     * @param value value of the entry.
-     */
-    fun putContextSync(key: String, value: ConfidenceValue)
-
-    /**
-     * Remove entry from context
-     * @param key key of the context to be removed.
-     */
-    fun removeContextSync(key: String)
+    fun removeContext(key: String)
 }

--- a/Confidence/src/main/java/com/spotify/confidence/ConfidenceContext.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/ConfidenceContext.kt
@@ -20,18 +20,37 @@ interface Contextual : ConfidenceContextProvider {
      * Add entry to context
      * @param context context to add.
      */
-    fun putContext(context: Map<String, ConfidenceValue>)
+    suspend fun putContext(context: Map<String, ConfidenceValue>)
 
     /**
      * Add entry to context
      * @param key key of the entry.
      * @param value value of the entry.
      */
-    fun putContext(key: String, value: ConfidenceValue)
+    suspend fun putContext(key: String, value: ConfidenceValue)
 
     /**
      * Remove entry from context
      * @param key key of the context to be removed.
      */
-    fun removeContext(key: String)
+    suspend fun removeContext(key: String)
+
+    /**
+     * Add entry to context
+     * @param context context to add.
+     */
+    fun putContextSync(context: Map<String, ConfidenceValue>)
+
+    /**
+     * Add entry to context
+     * @param key key of the entry.
+     * @param value value of the entry.
+     */
+    fun putContextSync(key: String, value: ConfidenceValue)
+
+    /**
+     * Remove entry from context
+     * @param key key of the context to be removed.
+     */
+    fun removeContextSync(key: String)
 }

--- a/Confidence/src/test/java/com/spotify/confidence/ConfidenceContextualTests.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/ConfidenceContextualTests.kt
@@ -28,7 +28,7 @@ class ConfidenceContextualTests {
         mutableMap["hello"] = ConfidenceValue.Boolean(false)
         mutableMap["NN"] = ConfidenceValue.Double(20.0)
         mutableMap["my_struct"] = ConfidenceValue.Struct(mapOf("x" to ConfidenceValue.Double(2.0)))
-        confidence.putContext(mutableMap)
+        confidence.putContextSync(mutableMap)
         val eventSender = confidence.withContext(mapOf("my_value" to ConfidenceValue.String("my value")))
         Assert.assertEquals(mutableMap, confidence.getContext())
         Assert.assertTrue(mutableMap.all { eventSender.getContext().containsKey(it.key) })
@@ -58,7 +58,7 @@ class ConfidenceContextualTests {
         mutableMap["hello"] = ConfidenceValue.Boolean(false)
         mutableMap["NN"] = ConfidenceValue.Double(20.0)
         mutableMap["my_struct"] = ConfidenceValue.Struct(mapOf("x" to ConfidenceValue.Double(2.0)))
-        confidence.putContext(mutableMap)
+        confidence.putContextSync(mutableMap)
         val eventSender = confidence.withContext(mapOf("my_value" to ConfidenceValue.String("my value")))
         Assert.assertEquals(mutableMap, confidence.getContext())
         Assert.assertTrue(mutableMap.all { eventSender.getContext().containsKey(it.key) })
@@ -67,7 +67,7 @@ class ConfidenceContextualTests {
 
         // remove the screen
         Assert.assertTrue(eventSender.getContext().containsKey("screen"))
-        eventSender.removeContext("screen")
+        eventSender.removeContextSync("screen")
         Assert.assertTrue(!eventSender.getContext().containsKey("screen"))
     }
 }

--- a/Confidence/src/test/java/com/spotify/confidence/ConfidenceContextualTests.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/ConfidenceContextualTests.kt
@@ -28,7 +28,7 @@ class ConfidenceContextualTests {
         mutableMap["hello"] = ConfidenceValue.Boolean(false)
         mutableMap["NN"] = ConfidenceValue.Double(20.0)
         mutableMap["my_struct"] = ConfidenceValue.Struct(mapOf("x" to ConfidenceValue.Double(2.0)))
-        confidence.putContextSync(mutableMap)
+        confidence.putContext(mutableMap)
         val eventSender = confidence.withContext(mapOf("my_value" to ConfidenceValue.String("my value")))
         Assert.assertEquals(mutableMap, confidence.getContext())
         Assert.assertTrue(mutableMap.all { eventSender.getContext().containsKey(it.key) })
@@ -58,7 +58,7 @@ class ConfidenceContextualTests {
         mutableMap["hello"] = ConfidenceValue.Boolean(false)
         mutableMap["NN"] = ConfidenceValue.Double(20.0)
         mutableMap["my_struct"] = ConfidenceValue.Struct(mapOf("x" to ConfidenceValue.Double(2.0)))
-        confidence.putContextSync(mutableMap)
+        confidence.putContext(mutableMap)
         val eventSender = confidence.withContext(mapOf("my_value" to ConfidenceValue.String("my value")))
         Assert.assertEquals(mutableMap, confidence.getContext())
         Assert.assertTrue(mutableMap.all { eventSender.getContext().containsKey(it.key) })
@@ -67,7 +67,7 @@ class ConfidenceContextualTests {
 
         // remove the screen
         Assert.assertTrue(eventSender.getContext().containsKey("screen"))
-        eventSender.removeContextSync("screen")
+        eventSender.removeContext("screen")
         Assert.assertTrue(!eventSender.getContext().containsKey("screen"))
     }
 }

--- a/Confidence/src/test/java/com/spotify/confidence/ConfidenceEvaluationTest.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/ConfidenceEvaluationTest.kt
@@ -365,7 +365,7 @@ internal class ConfidenceEvaluationTest {
             "default"
         )
         TestCase.assertEquals("red", evalString1.value)
-        mockConfidence.putContext(context2)
+        mockConfidence.putContextAndAwait(context2)
         advanceUntilIdle()
         val evalString2 = mockConfidence.getFlag(
             "test-kotlin-flag-1.mystring",
@@ -435,7 +435,7 @@ internal class ConfidenceEvaluationTest {
                 )
             )
         )
-        mockConfidence.putContext(context2)
+        mockConfidence.putContextAndAwait(context2)
         advanceUntilIdle()
         verify(flagResolverClient, times(1))
             .resolve(any(), eq(context2))
@@ -501,7 +501,7 @@ internal class ConfidenceEvaluationTest {
         flagResolver.returnCount = 0
         TestCase.assertEquals(mockConfidence.getContext(), context1)
         TestCase.assertEquals(context1, flagResolver.latestCalledContext)
-        mockConfidence.putContext(context2)
+        mockConfidence.putContextAndAwait(context2)
         advanceUntilIdle()
         TestCase.assertEquals(mockConfidence.getContext(), context2)
         TestCase.assertEquals(context2, flagResolver.latestCalledContext)
@@ -535,7 +535,7 @@ internal class ConfidenceEvaluationTest {
         TestCase.assertEquals(evalString.reason, ResolveReason.RESOLVE_REASON_MATCH)
         TestCase.assertEquals(evalString.value, "red")
 
-        mockConfidence.putContext("hello", ConfidenceValue.String("new context"))
+        mockConfidence.putContextAndAwait("hello", ConfidenceValue.String("new context"))
         val newContextEval = mockConfidence.getFlag(
             "test-kotlin-flag-1.mystring",
             "default"

--- a/Provider/src/main/java/com/spotify/confidence/openfeature/ConfidenceFeatureProvider.kt
+++ b/Provider/src/main/java/com/spotify/confidence/openfeature/ConfidenceFeatureProvider.kt
@@ -46,7 +46,7 @@ class ConfidenceFeatureProvider private constructor(
 
     override fun initialize(initialContext: EvaluationContext?) {
         initialContext?.toConfidenceContext()?.let {
-            confidence.putContextSync(it.map)
+            confidence.putContext(it.map)
         }
 
         when (initialisationStrategy) {
@@ -75,7 +75,7 @@ class ConfidenceFeatureProvider private constructor(
         val context = newContext.toConfidenceContext()
         val removedKeys = oldContext?.asMap()?.keys?.minus(newContext.asMap().keys) ?: emptySet()
         coroutineScope.launch {
-            confidence.putContext(context.map, removedKeys.toList())
+            confidence.putContextAndAwait(context.map, removedKeys.toList())
         }
     }
 

--- a/Provider/src/main/java/com/spotify/confidence/openfeature/ConfidenceFeatureProvider.kt
+++ b/Provider/src/main/java/com/spotify/confidence/openfeature/ConfidenceFeatureProvider.kt
@@ -46,7 +46,7 @@ class ConfidenceFeatureProvider private constructor(
 
     override fun initialize(initialContext: EvaluationContext?) {
         initialContext?.toConfidenceContext()?.let {
-            confidence.putContext(it.map)
+            confidence.putContextSync(it.map)
         }
 
         when (initialisationStrategy) {
@@ -74,7 +74,9 @@ class ConfidenceFeatureProvider private constructor(
     ) {
         val context = newContext.toConfidenceContext()
         val removedKeys = oldContext?.asMap()?.keys?.minus(newContext.asMap().keys) ?: emptySet()
-        confidence.putContext(context.map, removedKeys.toList())
+        coroutineScope.launch {
+            confidence.putContext(context.map, removedKeys.toList())
+        }
     }
 
     override fun observe(): Flow<OpenFeatureEvents> = eventHandler.observe()


### PR DESCRIPTION
This is a breaking change since the functions go from being non suspending to suspending.
quick and easy way to solve the race condition in awaitReconciliation()