### PR TITLE
fix: await reconciliation bug

### DIFF
--- a/Confidence/api/Confidence.api
+++ b/Confidence/api/Confidence.api
@@ -33,7 +33,8 @@ public final class com/spotify/confidence/Confidence : com/spotify/confidence/Co
 	public final fun activate ()V
 	public final fun apply (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun asyncFetch ()V
-	public final fun awaitReconciliation (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun awaitReconciliation (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun awaitReconciliation$default (Lcom/spotify/confidence/Confidence;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun fetchAndActivate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun flush ()V
 	public fun getContext ()Ljava/util/Map;

--- a/Confidence/src/main/java/com/spotify/confidence/Confidence.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/Confidence.kt
@@ -15,11 +15,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToJsonElement
@@ -66,7 +66,7 @@ class Confidence internal constructor(
     suspend fun awaitReconciliation(timeoutMillis: Long = 5000) {
         if (timeoutMillis <= 0) error("timeoutMillis need to be larger than 0")
         debugLogger?.logMessage("reconciliation started")
-        coroutineScope.async {}.await() // will make sure that we respect other coroutine scopes triggered before this
+        yield() // will make sure that we respect other coroutine scopes triggered before this
         withSafeTimeout(timeoutMillis) {
             currentFetchJob?.join()
             activate()


### PR DESCRIPTION
There was a case for race conditions that could occur when calling putContext() followed by a awaitReconciliation() where the contextChanges updates did not trigger a fetchAndActivate before awaitReconciliation had finished.

Replaces https://github.com/spotify/confidence-sdk-android/pull/185