### PR TITLE
feat!: refactor context provider

### DIFF
--- a/Confidence/api/Confidence.api
+++ b/Confidence/api/Confidence.api
@@ -33,7 +33,7 @@ public abstract interface class com/spotify/confidence/ConfidenceContextProvider
 	public abstract fun getContext ()Ljava/util/Map;
 }
 
-public final class com/spotify/confidence/ConfidenceDeviceInfoContextProducer : com/spotify/confidence/ContextProducer {
+public final class com/spotify/confidence/ConfidenceDeviceInfoContextProducer : com/spotify/confidence/Producer {
 	public static final field APP_BUILD_CONTEXT_KEY Ljava/lang/String;
 	public static final field APP_NAMESPACE_CONTEXT_KEY Ljava/lang/String;
 	public static final field APP_VERSION_CONTEXT_KEY Ljava/lang/String;
@@ -379,9 +379,6 @@ public final class com/spotify/confidence/ConfidenceValueKt {
 	public static final fun toNetworkJson (Lcom/spotify/confidence/ConfidenceValue$Struct;)Ljava/lang/String;
 }
 
-public abstract interface class com/spotify/confidence/ContextProducer : com/spotify/confidence/Producer {
-}
-
 public abstract interface class com/spotify/confidence/Contextual : com/spotify/confidence/ConfidenceContextProvider {
 	public abstract fun putContext (Ljava/lang/String;Lcom/spotify/confidence/ConfidenceValue;)V
 	public abstract fun putContext (Ljava/util/Map;)V
@@ -407,9 +404,6 @@ public final class com/spotify/confidence/Evaluation {
 	public final fun getVariant ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-}
-
-public abstract interface class com/spotify/confidence/EventProducer : com/spotify/confidence/Producer {
 }
 
 public abstract interface class com/spotify/confidence/EventSender : com/spotify/confidence/Contextual {

--- a/Confidence/api/Confidence.api
+++ b/Confidence/api/Confidence.api
@@ -23,7 +23,7 @@ public final class com/spotify/confidence/Confidence : com/spotify/confidence/Co
 	public final fun putContext (Ljava/util/Map;Ljava/util/List;)V
 	public fun removeContext (Ljava/lang/String;)V
 	public fun stop ()V
-	public fun track (Lcom/spotify/confidence/EventProducer;)V
+	public fun track (Lcom/spotify/confidence/Producer;)V
 	public fun track (Ljava/lang/String;Ljava/util/Map;)V
 	public synthetic fun withContext (Ljava/util/Map;)Lcom/spotify/confidence/Contextual;
 	public fun withContext (Ljava/util/Map;)Lcom/spotify/confidence/EventSender;
@@ -356,6 +356,10 @@ public final class com/spotify/confidence/ConfidenceValueKt {
 	public static final fun toNetworkJson (Lcom/spotify/confidence/ConfidenceValue$Struct;)Ljava/lang/String;
 }
 
+public abstract interface class com/spotify/confidence/ContextProducer : com/spotify/confidence/Producer {
+	public abstract fun contextChanges ()Lkotlinx/coroutines/flow/Flow;
+}
+
 public abstract interface class com/spotify/confidence/Contextual : com/spotify/confidence/ConfidenceContextProvider {
 	public abstract fun putContext (Ljava/lang/String;Lcom/spotify/confidence/ConfidenceValue;)V
 	public abstract fun putContext (Ljava/util/Map;)V
@@ -399,16 +403,14 @@ public final class com/spotify/confidence/Event {
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class com/spotify/confidence/EventProducer {
-	public abstract fun contextChanges ()Lkotlinx/coroutines/flow/Flow;
+public abstract interface class com/spotify/confidence/EventProducer : com/spotify/confidence/Producer {
 	public abstract fun events ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun stop ()V
 }
 
 public abstract interface class com/spotify/confidence/EventSender : com/spotify/confidence/Contextual {
 	public abstract fun flush ()V
 	public abstract fun stop ()V
-	public abstract fun track (Lcom/spotify/confidence/EventProducer;)V
+	public abstract fun track (Lcom/spotify/confidence/Producer;)V
 	public abstract fun track (Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun withContext (Ljava/util/Map;)Lcom/spotify/confidence/EventSender;
 }
@@ -465,6 +467,10 @@ public final class com/spotify/confidence/LoggingLevel : java/lang/Enum {
 	public static final field WARN Lcom/spotify/confidence/LoggingLevel;
 	public static fun valueOf (Ljava/lang/String;)Lcom/spotify/confidence/LoggingLevel;
 	public static fun values ()[Lcom/spotify/confidence/LoggingLevel;
+}
+
+public abstract interface class com/spotify/confidence/Producer {
+	public abstract fun stop ()V
 }
 
 public abstract interface class com/spotify/confidence/ProviderCache {

--- a/Confidence/api/Confidence.api
+++ b/Confidence/api/Confidence.api
@@ -1,26 +1,3 @@
-public final class com/spotify/confidence/AndroidLifecycleEventProducer : android/app/Application$ActivityLifecycleCallbacks, androidx/lifecycle/DefaultLifecycleObserver, com/spotify/confidence/EventProducer {
-	public static final field Companion Lcom/spotify/confidence/AndroidLifecycleEventProducer$Companion;
-	public fun <init> (Landroid/app/Application;Z)V
-	public fun contextChanges ()Lkotlinx/coroutines/flow/Flow;
-	public fun events ()Lkotlinx/coroutines/flow/Flow;
-	public fun onActivityCreated (Landroid/app/Activity;Landroid/os/Bundle;)V
-	public fun onActivityDestroyed (Landroid/app/Activity;)V
-	public fun onActivityPaused (Landroid/app/Activity;)V
-	public fun onActivityResumed (Landroid/app/Activity;)V
-	public fun onActivitySaveInstanceState (Landroid/app/Activity;Landroid/os/Bundle;)V
-	public fun onActivityStarted (Landroid/app/Activity;)V
-	public fun onActivityStopped (Landroid/app/Activity;)V
-	public fun onCreate (Landroidx/lifecycle/LifecycleOwner;)V
-	public fun stop ()V
-}
-
-public final class com/spotify/confidence/AndroidLifecycleEventProducer$Companion {
-}
-
-public final class com/spotify/confidence/AndroidLifecycleEventProducerKt {
-	public static final fun getReferrer (Landroid/app/Activity;)Landroid/net/Uri;
-}
-
 public final class com/spotify/confidence/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
 	public static final field DEBUG Z

--- a/Confidence/api/Confidence.api
+++ b/Confidence/api/Confidence.api
@@ -33,6 +33,26 @@ public abstract interface class com/spotify/confidence/ConfidenceContextProvider
 	public abstract fun getContext ()Ljava/util/Map;
 }
 
+public final class com/spotify/confidence/ConfidenceDeviceInfoContextProducer : com/spotify/confidence/ContextProducer {
+	public static final field APP_BUILD_CONTEXT_KEY Ljava/lang/String;
+	public static final field APP_VERSION_CONTEXT_KEY Ljava/lang/String;
+	public static final field BUNDLE_ID_CONTEXT_KEY Ljava/lang/String;
+	public static final field Companion Lcom/spotify/confidence/ConfidenceDeviceInfoContextProducer$Companion;
+	public static final field DEVICE_BRAND_CONTEXT_KEY Ljava/lang/String;
+	public static final field DEVICE_MODEL_CONTEXT_KEY Ljava/lang/String;
+	public static final field LOCAL_IDENTIFIER_CONTEXT_KEY Ljava/lang/String;
+	public static final field PREFERRED_LANGUAGES_CONTEXT_KEY Ljava/lang/String;
+	public static final field SYSTEM_NAME_CONTEXT_KEY Ljava/lang/String;
+	public static final field SYSTEM_VERSION_CONTEXT_KEY Ljava/lang/String;
+	public fun <init> (Landroid/content/Context;ZZZZ)V
+	public synthetic fun <init> (Landroid/content/Context;ZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun contextChanges ()Lkotlinx/coroutines/flow/Flow;
+	public fun stop ()V
+}
+
+public final class com/spotify/confidence/ConfidenceDeviceInfoContextProducer$Companion {
+}
+
 public final class com/spotify/confidence/ConfidenceError {
 	public fun <init> ()V
 }

--- a/Confidence/api/Confidence.api
+++ b/Confidence/api/Confidence.api
@@ -35,19 +35,21 @@ public abstract interface class com/spotify/confidence/ConfidenceContextProvider
 
 public final class com/spotify/confidence/ConfidenceDeviceInfoContextProducer : com/spotify/confidence/ContextProducer {
 	public static final field APP_BUILD_CONTEXT_KEY Ljava/lang/String;
+	public static final field APP_NAMESPACE_CONTEXT_KEY Ljava/lang/String;
 	public static final field APP_VERSION_CONTEXT_KEY Ljava/lang/String;
-	public static final field BUNDLE_ID_CONTEXT_KEY Ljava/lang/String;
 	public static final field Companion Lcom/spotify/confidence/ConfidenceDeviceInfoContextProducer$Companion;
 	public static final field DEVICE_BRAND_CONTEXT_KEY Ljava/lang/String;
+	public static final field DEVICE_MANUFACTURER_CONTEXT_KEY Ljava/lang/String;
 	public static final field DEVICE_MODEL_CONTEXT_KEY Ljava/lang/String;
-	public static final field LOCAL_IDENTIFIER_CONTEXT_KEY Ljava/lang/String;
+	public static final field DEVICE_TYPE_CONTEXT_KEY Ljava/lang/String;
+	public static final field LOCALE_CONTEXT_KEY Ljava/lang/String;
+	public static final field OS_NAME_CONTEXT_KEY Ljava/lang/String;
+	public static final field OS_VERSION_CONTEXT_KEY Ljava/lang/String;
 	public static final field PREFERRED_LANGUAGES_CONTEXT_KEY Ljava/lang/String;
-	public static final field SYSTEM_NAME_CONTEXT_KEY Ljava/lang/String;
-	public static final field SYSTEM_VERSION_CONTEXT_KEY Ljava/lang/String;
 	public fun <init> (Landroid/content/Context;ZZZZ)V
 	public synthetic fun <init> (Landroid/content/Context;ZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun contextChanges ()Lkotlinx/coroutines/flow/Flow;
 	public fun stop ()V
+	public fun updates ()Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class com/spotify/confidence/ConfidenceDeviceInfoContextProducer$Companion {
@@ -283,6 +285,7 @@ public final class com/spotify/confidence/ConfidenceValue$List$Companion {
 public final class com/spotify/confidence/ConfidenceValue$Null : com/spotify/confidence/ConfidenceValue {
 	public static final field INSTANCE Lcom/spotify/confidence/ConfidenceValue$Null;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/spotify/confidence/ConfidenceValue$String : com/spotify/confidence/ConfidenceValue {
@@ -377,7 +380,6 @@ public final class com/spotify/confidence/ConfidenceValueKt {
 }
 
 public abstract interface class com/spotify/confidence/ContextProducer : com/spotify/confidence/Producer {
-	public abstract fun contextChanges ()Lkotlinx/coroutines/flow/Flow;
 }
 
 public abstract interface class com/spotify/confidence/Contextual : com/spotify/confidence/ConfidenceContextProvider {
@@ -407,24 +409,7 @@ public final class com/spotify/confidence/Evaluation {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/spotify/confidence/Event {
-	public fun <init> (Ljava/lang/String;Ljava/util/Map;Z)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/util/Map;
-	public final fun component3 ()Z
-	public final fun copy (Ljava/lang/String;Ljava/util/Map;Z)Lcom/spotify/confidence/Event;
-	public static synthetic fun copy$default (Lcom/spotify/confidence/Event;Ljava/lang/String;Ljava/util/Map;ZILjava/lang/Object;)Lcom/spotify/confidence/Event;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getData ()Ljava/util/Map;
-	public final fun getName ()Ljava/lang/String;
-	public final fun getShouldFlush ()Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
 public abstract interface class com/spotify/confidence/EventProducer : com/spotify/confidence/Producer {
-	public abstract fun events ()Lkotlinx/coroutines/flow/Flow;
 }
 
 public abstract interface class com/spotify/confidence/EventSender : com/spotify/confidence/Contextual {
@@ -491,6 +476,7 @@ public final class com/spotify/confidence/LoggingLevel : java/lang/Enum {
 
 public abstract interface class com/spotify/confidence/Producer {
 	public abstract fun stop ()V
+	public abstract fun updates ()Lkotlinx/coroutines/flow/Flow;
 }
 
 public abstract interface class com/spotify/confidence/ProviderCache {
@@ -535,6 +521,36 @@ public final class com/spotify/confidence/Result$Success : com/spotify/confidenc
 	public static synthetic fun copy$default (Lcom/spotify/confidence/Result$Success;Ljava/lang/Object;ILjava/lang/Object;)Lcom/spotify/confidence/Result$Success;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getData ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/spotify/confidence/Update {
+}
+
+public final class com/spotify/confidence/Update$ContextUpdate : com/spotify/confidence/Update {
+	public fun <init> (Ljava/util/Map;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;)Lcom/spotify/confidence/Update$ContextUpdate;
+	public static synthetic fun copy$default (Lcom/spotify/confidence/Update$ContextUpdate;Ljava/util/Map;ILjava/lang/Object;)Lcom/spotify/confidence/Update$ContextUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContext ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/spotify/confidence/Update$Event : com/spotify/confidence/Update {
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;Z)Lcom/spotify/confidence/Update$Event;
+	public static synthetic fun copy$default (Lcom/spotify/confidence/Update$Event;Ljava/lang/String;Ljava/util/Map;ZILjava/lang/Object;)Lcom/spotify/confidence/Update$Event;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/util/Map;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getShouldFlush ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/Confidence/build.gradle.kts
+++ b/Confidence/build.gradle.kts
@@ -54,7 +54,6 @@ dependencies {
     implementation(
         "org.jetbrains.kotlinx:kotlinx-serialization-json:${Versions.kotlinxSerialization}"
     )
-    implementation("androidx.lifecycle:lifecycle-process:2.6.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}")
     testImplementation("junit:junit:${Versions.junit}")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.coroutines}")

--- a/Confidence/src/main/java/com/spotify/confidence/ConfidenceDeviceInfoContextProducer.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/ConfidenceDeviceInfoContextProducer.kt
@@ -11,9 +11,9 @@ import java.util.Locale
 
 class ConfidenceDeviceInfoContextProducer(
     applicationContext: Context,
-    withVersionInfo: Boolean = false,
-    withBundleId: Boolean = false,
+    withAppInfo: Boolean = false,
     withDeviceInfo: Boolean = false,
+    withOsInfo: Boolean = false,
     withLocale: Boolean = false
 ) : ContextProducer {
     private val contextFlow = MutableStateFlow<Map<String, ConfidenceValue>>(mapOf())
@@ -27,28 +27,39 @@ class ConfidenceDeviceInfoContextProducer(
 
     init {
         val context = mutableMapOf<String, ConfidenceValue>()
-        if (withVersionInfo) {
+        if (withAppInfo) {
             val currentVersion = ConfidenceValue.String(packageInfo?.versionName ?: "")
             val currentBuild = ConfidenceValue.String(packageInfo?.getVersionCodeAsString() ?: "")
-            val addedContext = mapOf(
-                APP_VERSION_CONTEXT_KEY to currentVersion,
-                APP_BUILD_CONTEXT_KEY to currentBuild
-            )
-            context += addedContext
-        }
-        if (withBundleId) {
             val bundleId = ConfidenceValue.String(applicationContext.packageName)
-            context += mapOf(BUNDLE_ID_CONTEXT_KEY to bundleId)
-        }
-        if (withDeviceInfo) {
-            val deviceInfo = mapOf(
-                SYSTEM_NAME_CONTEXT_KEY to ConfidenceValue.String("Android"),
-                DEVICE_BRAND_CONTEXT_KEY to ConfidenceValue.String(Build.BRAND),
-                DEVICE_MODEL_CONTEXT_KEY to ConfidenceValue.String(Build.MODEL),
-                SYSTEM_VERSION_CONTEXT_KEY to ConfidenceValue.Double(Build.VERSION.SDK_INT.toDouble())
+            context["app"] = ConfidenceValue.Struct(
+                mapOf(
+                    APP_VERSION_CONTEXT_KEY to currentVersion,
+                    APP_BUILD_CONTEXT_KEY to currentBuild,
+                    APP_NAMESPACE_CONTEXT_KEY to bundleId
+                )
             )
-            context += deviceInfo
         }
+
+        if (withDeviceInfo) {
+            context["device"] = ConfidenceValue.Struct(
+                mapOf(
+                    DEVICE_MANUFACTURER_CONTEXT_KEY to ConfidenceValue.String(Build.MANUFACTURER),
+                    DEVICE_BRAND_CONTEXT_KEY to ConfidenceValue.String(Build.BRAND),
+                    DEVICE_MODEL_CONTEXT_KEY to ConfidenceValue.String(Build.MODEL),
+                    DEVICE_TYPE_CONTEXT_KEY to ConfidenceValue.String("android")
+                )
+            )
+        }
+
+        if (withOsInfo) {
+            context["os"] = ConfidenceValue.Struct(
+                mapOf(
+                    OS_NAME_CONTEXT_KEY to ConfidenceValue.String("android"),
+                    OS_VERSION_CONTEXT_KEY to ConfidenceValue.Double(Build.VERSION.SDK_INT.toDouble())
+                )
+            )
+        }
+
         if (withLocale) {
             val preferredLang = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 val locales = applicationContext.resources.configuration.locales
@@ -58,9 +69,10 @@ class ConfidenceDeviceInfoContextProducer(
             }
             val localeIdentifier = Locale.getDefault().toString()
             val localeInfo = mapOf(
-                LOCAL_IDENTIFIER_CONTEXT_KEY to ConfidenceValue.String(localeIdentifier),
+                LOCALE_CONTEXT_KEY to ConfidenceValue.String(localeIdentifier),
                 PREFERRED_LANGUAGES_CONTEXT_KEY to ConfidenceValue.List(preferredLang.map(ConfidenceValue::String))
             )
+            // these are on the top level
             context += localeInfo
         }
         contextFlow.value = context
@@ -70,14 +82,16 @@ class ConfidenceDeviceInfoContextProducer(
     override fun stop() {}
 
     companion object {
-        const val APP_VERSION_CONTEXT_KEY = "app_version"
-        const val APP_BUILD_CONTEXT_KEY = "app_build"
-        const val BUNDLE_ID_CONTEXT_KEY = "bundle_id"
-        const val SYSTEM_NAME_CONTEXT_KEY = "system_name"
-        const val DEVICE_BRAND_CONTEXT_KEY = "device_brand"
-        const val DEVICE_MODEL_CONTEXT_KEY = "device_model"
-        const val SYSTEM_VERSION_CONTEXT_KEY = "system_version"
-        const val LOCAL_IDENTIFIER_CONTEXT_KEY = "locale_identifier"
+        const val APP_VERSION_CONTEXT_KEY = "version"
+        const val APP_BUILD_CONTEXT_KEY = "build"
+        const val APP_NAMESPACE_CONTEXT_KEY = "namespace"
+        const val DEVICE_MANUFACTURER_CONTEXT_KEY = "manufacturer"
+        const val DEVICE_BRAND_CONTEXT_KEY = "brand"
+        const val DEVICE_MODEL_CONTEXT_KEY = "model"
+        const val DEVICE_TYPE_CONTEXT_KEY = "type"
+        const val OS_NAME_CONTEXT_KEY = "name"
+        const val OS_VERSION_CONTEXT_KEY = "version"
+        const val LOCALE_CONTEXT_KEY = "locale"
         const val PREFERRED_LANGUAGES_CONTEXT_KEY = "preferred_languages"
     }
 }

--- a/Confidence/src/main/java/com/spotify/confidence/ConfidenceDeviceInfoContextProducer.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/ConfidenceDeviceInfoContextProducer.kt
@@ -1,0 +1,91 @@
+package com.spotify.confidence
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import java.util.Locale
+
+class ConfidenceDeviceInfoContextProducer(
+    applicationContext: Context,
+    withVersionInfo: Boolean = false,
+    withBundleId: Boolean = false,
+    withDeviceInfo: Boolean = false,
+    withLocale: Boolean = false,
+) : ContextProducer {
+    private val contextFlow = MutableStateFlow<Map<String, ConfidenceValue>>(mapOf())
+    private val packageInfo: PackageInfo? = try {
+        @Suppress("DEPRECATION")
+        applicationContext.packageManager.getPackageInfo(applicationContext.packageName, 0)
+    } catch (e: PackageManager.NameNotFoundException) {
+        Log.w(DebugLogger.TAG, "Failed to get package info", e)
+        null
+    }
+
+    init {
+        val context = mutableMapOf<String, ConfidenceValue>()
+        if (withVersionInfo) {
+            val currentVersion = ConfidenceValue.String(packageInfo?.versionName ?: "")
+            val currentBuild = ConfidenceValue.String(packageInfo?.getVersionCodeAsString() ?: "")
+            val addedContext = mapOf(
+                APP_VERSION_CONTEXT_KEY to currentVersion,
+                APP_BUILD_CONTEXT_KEY to currentBuild
+            )
+            context += addedContext
+        }
+        if (withBundleId) {
+            val bundleId = ConfidenceValue.String(applicationContext.packageName)
+            context += mapOf(BUNDLE_ID_CONTEXT_KEY to bundleId)
+        }
+        if (withDeviceInfo) {
+            val deviceInfo = mapOf(
+                SYSTEM_NAME_CONTEXT_KEY to ConfidenceValue.String("Android"),
+                DEVICE_BRAND_CONTEXT_KEY to ConfidenceValue.String(Build.BRAND),
+                DEVICE_MODEL_CONTEXT_KEY to ConfidenceValue.String(Build.MODEL),
+                SYSTEM_VERSION_CONTEXT_KEY to ConfidenceValue.Double(Build.VERSION.SDK_INT.toDouble())
+            )
+            context += deviceInfo
+        }
+        if (withLocale) {
+            val preferredLang = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                val locales = applicationContext.resources.configuration.locales
+                (0 until locales.size()).map { locales.get(it).toString() }
+            } else {
+                listOf(Locale.getDefault().toString())
+            }
+            val localeIdentifier = Locale.getDefault().toString()
+            val localeInfo = mapOf(
+                LOCAL_IDENTIFIER_CONTEXT_KEY to ConfidenceValue.String(localeIdentifier),
+                PREFERRED_LANGUAGES_CONTEXT_KEY to ConfidenceValue.List(preferredLang.map(ConfidenceValue::String))
+            )
+            context += localeInfo
+        }
+        contextFlow.value = context
+    }
+
+    override fun contextChanges(): Flow<Map<String, ConfidenceValue>> = contextFlow
+    override fun stop() {}
+
+    companion object {
+        const val APP_VERSION_CONTEXT_KEY = "app_version"
+        const val APP_BUILD_CONTEXT_KEY = "app_build"
+        const val BUNDLE_ID_CONTEXT_KEY = "bundle_id"
+        const val SYSTEM_NAME_CONTEXT_KEY = "system_name"
+        const val DEVICE_BRAND_CONTEXT_KEY = "device_brand"
+        const val DEVICE_MODEL_CONTEXT_KEY = "device_model"
+        const val SYSTEM_VERSION_CONTEXT_KEY = "system_version"
+        const val LOCAL_IDENTIFIER_CONTEXT_KEY = "locale_identifier"
+        const val PREFERRED_LANGUAGES_CONTEXT_KEY = "preferred_languages"
+    }
+}
+
+private fun PackageInfo.getVersionCodeAsString(): String =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        this.longVersionCode.toString()
+    } else {
+        @Suppress("DEPRECATION")
+        this.versionCode.toString()
+    }

--- a/Confidence/src/main/java/com/spotify/confidence/ConfidenceDeviceInfoContextProducer.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/ConfidenceDeviceInfoContextProducer.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.util.Log
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
 import java.util.Locale
 
 class ConfidenceDeviceInfoContextProducer(
@@ -78,7 +79,9 @@ class ConfidenceDeviceInfoContextProducer(
         contextFlow.value = context
     }
 
-    override fun contextChanges(): Flow<Map<String, ConfidenceValue>> = contextFlow
+    //    override fun contextChanges(): Flow<Map<String, ConfidenceValue>> = contextFlow
+    override fun updates(): Flow<Update> = contextFlow.map { Update.ContextUpdate(it) }
+
     override fun stop() {}
 
     companion object {

--- a/Confidence/src/main/java/com/spotify/confidence/ConfidenceDeviceInfoContextProducer.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/ConfidenceDeviceInfoContextProducer.kt
@@ -14,7 +14,7 @@ class ConfidenceDeviceInfoContextProducer(
     withVersionInfo: Boolean = false,
     withBundleId: Boolean = false,
     withDeviceInfo: Boolean = false,
-    withLocale: Boolean = false,
+    withLocale: Boolean = false
 ) : ContextProducer {
     private val contextFlow = MutableStateFlow<Map<String, ConfidenceValue>>(mapOf())
     private val packageInfo: PackageInfo? = try {

--- a/Confidence/src/main/java/com/spotify/confidence/ConfidenceValue.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/ConfidenceValue.kt
@@ -9,33 +9,51 @@ import kotlinx.serialization.json.Json
 @Serializable(ConfidenceValueSerializer::class)
 sealed interface ConfidenceValue {
     @Serializable
-    data class String(val string: kotlin.String) : ConfidenceValue
+    data class String(val string: kotlin.String) : ConfidenceValue {
+        override fun toString() = string
+    }
 
     @Serializable
-    data class Double(val double: kotlin.Double) : ConfidenceValue
+    data class Double(val double: kotlin.Double) : ConfidenceValue {
+        override fun toString() = double.toString()
+    }
 
     @Serializable
-    data class Boolean(val boolean: kotlin.Boolean) : ConfidenceValue
+    data class Boolean(val boolean: kotlin.Boolean) : ConfidenceValue {
+        override fun toString() = boolean.toString()
+    }
 
     @Serializable
-    data class Integer(val integer: Int) : ConfidenceValue
+    data class Integer(val integer: Int) : ConfidenceValue {
+        override fun toString() = integer.toString()
+    }
 
     @Serializable
-    data class Struct(val map: Map<kotlin.String, ConfidenceValue>) : ConfidenceValue
+    data class Struct(val map: Map<kotlin.String, ConfidenceValue>) : ConfidenceValue {
+        override fun toString() = map.toString()
+    }
 
     @Serializable
     data class List(val list: kotlin.collections.List<ConfidenceValue>) :
-        ConfidenceValue
+        ConfidenceValue {
+        override fun toString() = list.toString()
+    }
 
     @Serializable
-    data class Date(@Serializable(DateSerializer::class) val date: java.util.Date) : ConfidenceValue
+    data class Date(@Serializable(DateSerializer::class) val date: java.util.Date) : ConfidenceValue {
+        override fun toString() = date.toString()
+    }
 
     @Serializable
     data class Timestamp(@Serializable(DateTimeSerializer::class) val dateTime: java.util.Date) :
-        ConfidenceValue
+        ConfidenceValue {
+        override fun toString() = dateTime.toString()
+    }
 
     @Serializable
-    object Null : ConfidenceValue
+    object Null : ConfidenceValue {
+        override fun toString() = "null"
+    }
 
     companion object {
         fun stringList(list: kotlin.collections.List<kotlin.String>) =

--- a/Confidence/src/main/java/com/spotify/confidence/DebugLogger.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/DebugLogger.kt
@@ -4,14 +4,15 @@ import android.util.Log
 import kotlinx.serialization.json.JsonElement
 import java.net.URLEncoder
 
-private const val TAG = "Confidence"
-
 internal interface DebugLogger {
     fun logEvent(action: String, event: EngineEvent)
     fun logMessage(message: String, isWarning: Boolean = false, throwable: Throwable? = null)
     fun logFlag(action: String, details: String? = null)
     fun logContext(action: String, context: Map<String, ConfidenceValue>)
     fun logResolve(flag: String, context: JsonElement)
+    companion object {
+        const val TAG = "Confidence"
+    }
 }
 
 internal class DebugLoggerImpl(private val filterLevel: LoggingLevel, private val clientKey: String) : DebugLogger {
@@ -60,10 +61,10 @@ internal class DebugLoggerImpl(private val filterLevel: LoggingLevel, private va
     private fun log(messageLevel: LoggingLevel, message: String) {
         if (messageLevel >= filterLevel) {
             when (messageLevel) {
-                LoggingLevel.VERBOSE -> Log.v(TAG, message)
-                LoggingLevel.DEBUG -> Log.d(TAG, message)
-                LoggingLevel.WARN -> Log.w(TAG, message)
-                LoggingLevel.ERROR -> Log.e(TAG, message)
+                LoggingLevel.VERBOSE -> Log.v(DebugLogger.TAG, message)
+                LoggingLevel.DEBUG -> Log.d(DebugLogger.TAG, message)
+                LoggingLevel.WARN -> Log.w(DebugLogger.TAG, message)
+                LoggingLevel.ERROR -> Log.e(DebugLogger.TAG, message)
                 LoggingLevel.NONE -> {
                     // do nothing
                 }

--- a/Confidence/src/main/java/com/spotify/confidence/EventSender.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/EventSender.kt
@@ -12,7 +12,10 @@ interface EventSender : Contextual {
     )
 
     /**
-     * Track Android-specific events like activities or context updates.
+     * Track Android-specific events like activities or Track Context updates.
+     * Please note that this method is collecting data in a coroutine scope and will be
+     * executed on the dispatcher that was defined with the creation of the Confidence instance.
+     *
      * @param producer a producer that produces the events or context updates.
      */
     fun track(producer: Producer)

--- a/Confidence/src/main/java/com/spotify/confidence/EventSender.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/EventSender.kt
@@ -12,10 +12,10 @@ interface EventSender : Contextual {
     )
 
     /**
-     * Track Android-specific events like activities.
-     * @param eventProducer an eventProducer that produces the event, e.g. AndroidLifecycleEventProducer.
+     * Track Android-specific events like activities or context updates.
+     * @param producer a producer that produces the events or context updates.
      */
-    fun track(eventProducer: EventProducer)
+    fun track(producer: Producer)
 
     /**
      * Safely stop a Confidence instance

--- a/Confidence/src/main/java/com/spotify/confidence/Producer.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/Producer.kt
@@ -12,11 +12,12 @@ sealed interface Update {
     data class ContextUpdate(val context: Map<String, ConfidenceValue>) : Update
 }
 
-sealed interface Producer {
+/**
+ * A producer is a class that can produce updates to the confidence system.
+ * Currently, the only supported updates are a context update or an event update where an Event will be
+ * sent using the event sender engine.
+ */
+interface Producer {
     fun stop()
     fun updates(): Flow<Update>
 }
-
-interface EventProducer : Producer
-
-interface ContextProducer : Producer

--- a/Confidence/src/main/java/com/spotify/confidence/Producer.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/Producer.kt
@@ -8,7 +8,7 @@ data class Event(
     val shouldFlush: Boolean = false
 )
 
-interface Producer {
+sealed interface Producer {
     fun stop()
 }
 

--- a/Confidence/src/main/java/com/spotify/confidence/Producer.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/Producer.kt
@@ -8,9 +8,14 @@ data class Event(
     val shouldFlush: Boolean = false
 )
 
-interface EventProducer {
-    fun events(): Flow<Event>
-    fun contextChanges(): Flow<Map<String, ConfidenceValue>>
-
+interface Producer {
     fun stop()
+}
+
+interface EventProducer : Producer {
+    fun events(): Flow<Event>
+}
+
+interface ContextProducer : Producer {
+    fun contextChanges(): Flow<Map<String, ConfidenceValue>>
 }

--- a/Confidence/src/main/java/com/spotify/confidence/Producer.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/Producer.kt
@@ -2,20 +2,21 @@ package com.spotify.confidence
 
 import kotlinx.coroutines.flow.Flow
 
-data class Event(
-    val name: String,
-    val data: Map<String, ConfidenceValue>,
-    val shouldFlush: Boolean = false
-)
+sealed interface Update {
+    data class Event(
+        val name: String,
+        val data: Map<String, ConfidenceValue>,
+        val shouldFlush: Boolean = false
+    ) : Update
+
+    data class ContextUpdate(val context: Map<String, ConfidenceValue>) : Update
+}
 
 sealed interface Producer {
     fun stop()
+    fun updates(): Flow<Update>
 }
 
-interface EventProducer : Producer {
-    fun events(): Flow<Event>
-}
+interface EventProducer : Producer
 
-interface ContextProducer : Producer {
-    fun contextChanges(): Flow<Map<String, ConfidenceValue>>
-}
+interface ContextProducer : Producer

--- a/Confidence/src/test/java/com/spotify/confidence/ConfidenceEvaluationTest.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/ConfidenceEvaluationTest.kt
@@ -74,7 +74,7 @@ internal class ConfidenceEvaluationTest {
         cache: ProviderCache = InMemoryCache(),
         initialContext: Map<String, ConfidenceValue> = mapOf(),
         flagResolver: FlagResolver? = null,
-        debugLogger: DebugLoggerFake? = null
+        debugLogger: DebugLoggerFake? = null,
     ): Confidence =
         Confidence(
             clientSecret = "",
@@ -470,7 +470,7 @@ internal class ConfidenceEvaluationTest {
             var latestCalledContext = mapOf<String, ConfidenceValue>()
             override suspend fun resolve(
                 flags: List<String>,
-                context: Map<String, ConfidenceValue>
+                context: Map<String, ConfidenceValue>,
             ): Result<FlagResolution> {
                 latestCalledContext = context
                 callCount++

--- a/Confidence/src/test/java/com/spotify/confidence/ConfidenceEvaluationTest.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/ConfidenceEvaluationTest.kt
@@ -74,7 +74,7 @@ internal class ConfidenceEvaluationTest {
         cache: ProviderCache = InMemoryCache(),
         initialContext: Map<String, ConfidenceValue> = mapOf(),
         flagResolver: FlagResolver? = null,
-        debugLogger: DebugLoggerFake? = null,
+        debugLogger: DebugLoggerFake? = null
     ): Confidence =
         Confidence(
             clientSecret = "",
@@ -470,7 +470,7 @@ internal class ConfidenceEvaluationTest {
             var latestCalledContext = mapOf<String, ConfidenceValue>()
             override suspend fun resolve(
                 flags: List<String>,
-                context: Map<String, ConfidenceValue>,
+                context: Map<String, ConfidenceValue>
             ): Result<FlagResolution> {
                 latestCalledContext = context
                 callCount++

--- a/Confidence/src/test/java/com/spotify/confidence/ConfidenceProducerIntegrationTest.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/ConfidenceProducerIntegrationTest.kt
@@ -1,0 +1,65 @@
+package com.spotify.confidence
+
+import com.spotify.confidence.Update.Event
+import com.spotify.confidence.fakes.FakeDiskStorage
+import com.spotify.confidence.fakes.FakeEventSenderEngine
+import com.spotify.confidence.fakes.FakeFlagApplierClient
+import com.spotify.confidence.fakes.FakeFlagResolver
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class ConfidenceProducerIntegrationTest {
+
+    private lateinit var engine: FakeEventSenderEngine
+
+    @Before
+    fun setUp() {
+        engine = FakeEventSenderEngine()
+    }
+
+    class MyProducer : EventProducer, ContextProducer {
+        private val flow = MutableSharedFlow<Update>()
+        override fun updates(): Flow<Update> = flow
+        override fun stop() {}
+        suspend fun emitContextChange(map: Map<String, ConfidenceValue.String>) = flow.emit(Update.ContextUpdate(map))
+        suspend fun emitEvent(event: Event) = flow.emit(event)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testSomething() = runTest {
+        val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+//        val testDispatcher = StandardTestDispatcher(testScheduler) //does not work... why?
+        val producerUnderTest = MyProducer()
+        val confidence = Confidence(
+            clientSecret = "secret",
+            dispatcher = testDispatcher,
+            diskStorage = FakeDiskStorage(),
+            eventSenderEngine = engine,
+            flagResolver = FakeFlagResolver(),
+            debugLogger = null,
+            flagApplierClient = FakeFlagApplierClient()
+        )
+
+        confidence.track(producerUnderTest)
+
+        producerUnderTest.emitContextChange(
+            mapOf("key" to ConfidenceValue.String("value"))
+        )
+        producerUnderTest.emitEvent(
+            Event("event", mapOf("key" to ConfidenceValue.String("value")))
+        )
+
+        Assert.assertEquals("value", (confidence.getContext()["key"] as? ConfidenceValue.String)?.string)
+        Assert.assertEquals(1, engine.list.size)
+        Assert.assertEquals(ConfidenceValue.String("value"), engine.list.first().third["key"])
+
+        confidence.stop()
+    }
+}

--- a/Confidence/src/test/java/com/spotify/confidence/ConfidenceProducerIntegrationTest.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/ConfidenceProducerIntegrationTest.kt
@@ -23,7 +23,7 @@ class ConfidenceProducerIntegrationTest {
         engine = FakeEventSenderEngine()
     }
 
-    class MyProducer : EventProducer, ContextProducer {
+    class MyProducer : Producer {
         private val flow = MutableSharedFlow<Update>()
         override fun updates(): Flow<Update> = flow
         override fun stop() {}

--- a/Confidence/src/test/java/com/spotify/confidence/DebugLoggerImplTest.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/DebugLoggerImplTest.kt
@@ -72,7 +72,7 @@ class DebugLoggerImplTest {
     @Test
     fun logContextLogsOnVerboseLevel() {
         verboseLogger.logContext("action", mapOf("key" to ConfidenceValue.String("value")))
-        verify { Log.v("Confidence", "[action] {key=String(string=value)}") }
+        verify { Log.v("Confidence", "[action] {key=value}") }
     }
 
     @Test

--- a/Confidence/src/test/java/com/spotify/confidence/StorageFileCacheTests.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/StorageFileCacheTests.kt
@@ -112,7 +112,7 @@ class StorageFileCacheTests {
         dispatcher: CoroutineDispatcher,
         cache: ProviderCache = mock(),
         initialContext: Map<String, ConfidenceValue> = mapOf(),
-        debugLogger: DebugLoggerFake = DebugLoggerFake(),
+        debugLogger: DebugLoggerFake = DebugLoggerFake()
     ) = Confidence(
         clientSecret = "",
         dispatcher = dispatcher,

--- a/Confidence/src/test/java/com/spotify/confidence/StorageFileCacheTests.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/StorageFileCacheTests.kt
@@ -112,7 +112,7 @@ class StorageFileCacheTests {
         dispatcher: CoroutineDispatcher,
         cache: ProviderCache = mock(),
         initialContext: Map<String, ConfidenceValue> = mapOf(),
-        debugLogger: DebugLoggerFake = DebugLoggerFake()
+        debugLogger: DebugLoggerFake = DebugLoggerFake(),
     ) = Confidence(
         clientSecret = "",
         dispatcher = dispatcher,

--- a/Confidence/src/test/java/com/spotify/confidence/fakes/FakeDiskStorage.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/fakes/FakeDiskStorage.kt
@@ -1,0 +1,25 @@
+package com.spotify.confidence.fakes
+
+import com.spotify.confidence.FlagResolution
+import com.spotify.confidence.apply.ApplyInstance
+import com.spotify.confidence.cache.DiskStorage
+
+class FakeDiskStorage() : DiskStorage {
+    override fun store(flagResolution: FlagResolution) {
+        TODO("Not yet implemented")
+    }
+
+    override fun read(): FlagResolution = FlagResolution.EMPTY
+
+    override fun clear() {
+        TODO("Not yet implemented")
+    }
+
+    override fun writeApplyData(applyData: Map<String, MutableMap<String, ApplyInstance>>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun readApplyData(): MutableMap<String, MutableMap<String, ApplyInstance>> {
+        return emptyMap<String, MutableMap<String, ApplyInstance>>().toMutableMap()
+    }
+}

--- a/Confidence/src/test/java/com/spotify/confidence/fakes/FakeEventSenderEngine.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/fakes/FakeEventSenderEngine.kt
@@ -1,0 +1,26 @@
+package com.spotify.confidence.fakes
+
+import com.spotify.confidence.ConfidenceFieldsType
+import com.spotify.confidence.ConfidenceValue
+import com.spotify.confidence.EventSenderEngine
+import kotlinx.coroutines.channels.Channel
+import java.io.File
+
+class FakeEventSenderEngine() : EventSenderEngine {
+
+    val list: MutableList<Triple<String, ConfidenceFieldsType, Map<String, ConfidenceValue>>> = mutableListOf()
+
+    override fun onLowMemoryChannel(): Channel<List<File>> {
+        TODO("Not yet implemented")
+    }
+
+    override fun emit(eventName: String, data: ConfidenceFieldsType, context: Map<String, ConfidenceValue>) {
+        list.add(Triple(eventName, data, context))
+    }
+
+    override fun flush() {
+    }
+
+    override fun stop() {
+    }
+}

--- a/Confidence/src/test/java/com/spotify/confidence/fakes/FakeFlagApplierClient.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/fakes/FakeFlagApplierClient.kt
@@ -1,0 +1,11 @@
+package com.spotify.confidence.fakes
+
+import com.spotify.confidence.Result
+import com.spotify.confidence.client.AppliedFlag
+import com.spotify.confidence.client.FlagApplierClient
+
+class FakeFlagApplierClient : FlagApplierClient {
+    override suspend fun apply(flags: List<AppliedFlag>, resolveToken: String): Result<Unit> {
+        TODO("Not yet implemented")
+    }
+}

--- a/Confidence/src/test/java/com/spotify/confidence/fakes/FakeFlagResolver.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/fakes/FakeFlagResolver.kt
@@ -1,0 +1,12 @@
+package com.spotify.confidence.fakes
+
+import com.spotify.confidence.ConfidenceValue
+import com.spotify.confidence.FlagResolution
+import com.spotify.confidence.FlagResolver
+import com.spotify.confidence.Result
+
+class FakeFlagResolver : FlagResolver {
+    override suspend fun resolve(flags: List<String>, context: Map<String, ConfidenceValue>): Result<FlagResolution> {
+        TODO("Not yet implemented")
+    }
+}

--- a/ConfidenceDemoApp/build.gradle.kts
+++ b/ConfidenceDemoApp/build.gradle.kts
@@ -84,6 +84,7 @@ android {
 
 dependencies {
     implementation(project(":Confidence"))
+    implementation("androidx.lifecycle:lifecycle-process:2.6.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}")
     implementation( "androidx.compose.runtime:runtime-livedata:${Versions.liveData}")
     implementation( "androidx.core:core-ktx:${Versions.core}")

--- a/ConfidenceDemoApp/src/main/java/com/example/confidencedemoapp/AndroidLifecycleEventProducer.kt
+++ b/ConfidenceDemoApp/src/main/java/com/example/confidencedemoapp/AndroidLifecycleEventProducer.kt
@@ -15,8 +15,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.spotify.confidence.ConfidenceValue
-import com.spotify.confidence.Event
 import com.spotify.confidence.EventProducer
+import com.spotify.confidence.Update
+import com.spotify.confidence.Update.Event
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -142,7 +143,7 @@ class AndroidLifecycleEventProducer(
         }
     }
 
-    override fun events(): Flow<Event> = eventsFlow
+    override fun updates(): Flow<Update> = eventsFlow
 
     override fun stop() {
         if (trackActivities) {

--- a/ConfidenceDemoApp/src/main/java/com/example/confidencedemoapp/AndroidLifecycleEventProducer.kt
+++ b/ConfidenceDemoApp/src/main/java/com/example/confidencedemoapp/AndroidLifecycleEventProducer.kt
@@ -118,7 +118,7 @@ class AndroidLifecycleEventProducer(
         val packageInfo = packageInfo
         val currentVersion = ConfidenceValue.String(packageInfo?.versionName ?: "")
         val currentBuild = ConfidenceValue.String(packageInfo?.getVersionCode().toString() ?: "")
-        
+
         val previousBuild: ConfidenceValue.String? = sharedPreferences
             .getString(APP_BUILD, null)
             ?.let(ConfidenceValue::String)

--- a/ConfidenceDemoApp/src/main/java/com/example/confidencedemoapp/AndroidLifecycleEventProducer.kt
+++ b/ConfidenceDemoApp/src/main/java/com/example/confidencedemoapp/AndroidLifecycleEventProducer.kt
@@ -1,4 +1,4 @@
-package com.spotify.confidence
+package com.example.confidencedemoapp
 
 import android.app.Activity
 import android.app.Application
@@ -14,6 +14,9 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
+import com.spotify.confidence.ConfidenceValue
+import com.spotify.confidence.Event
+import com.spotify.confidence.EventProducer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -125,11 +128,6 @@ class AndroidLifecycleEventProducer(
         val currentVersion = ConfidenceValue.String(packageInfo?.versionName ?: "")
         val currentBuild = ConfidenceValue.String(packageInfo?.getVersionCode().toString() ?: "")
 
-        val addedContext = mapOf(
-            APP_VERSION_KEY to currentVersion,
-            APP_BUILD_KEY to currentBuild
-        )
-        updateContext(addedContext)
 
         val previousBuild: ConfidenceValue.String? = sharedPreferences
             .getString(APP_BUILD, null)
@@ -171,10 +169,6 @@ class AndroidLifecycleEventProducer(
         private const val APP_VERSION = "APP_VERSION"
         private const val APP_BUILD = "APP_BUILD"
         private const val LEGACY_APP_BUILD = "LEGACY_APP_BUILD"
-
-        // Context keys
-        private const val APP_VERSION_KEY = "app_version"
-        private const val APP_BUILD_KEY = "app_build"
 
         // Event keys
         private const val APP_INSTALLED_EVENT = "app-installed"

--- a/ConfidenceDemoApp/src/main/java/com/example/confidencedemoapp/AndroidLifecycleEventProducer.kt
+++ b/ConfidenceDemoApp/src/main/java/com/example/confidencedemoapp/AndroidLifecycleEventProducer.kt
@@ -15,7 +15,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.spotify.confidence.ConfidenceValue
-import com.spotify.confidence.EventProducer
+import com.spotify.confidence.Producer
 import com.spotify.confidence.Update
 import com.spotify.confidence.Update.Event
 import kotlinx.coroutines.CoroutineScope
@@ -27,7 +27,7 @@ import kotlinx.coroutines.launch
 class AndroidLifecycleEventProducer(
     private val application: Application,
     private val trackActivities: Boolean
-) : Application.ActivityLifecycleCallbacks, DefaultLifecycleObserver, EventProducer {
+) : Application.ActivityLifecycleCallbacks, DefaultLifecycleObserver, Producer {
     private val eventsFlow = MutableSharedFlow<Event>()
     private val sharedPreferences by lazy {
         application.getSharedPreferences("CONFIDENCE_EVENTS", Context.MODE_PRIVATE)

--- a/ConfidenceDemoApp/src/main/java/com/example/confidencedemoapp/MainVm.kt
+++ b/ConfidenceDemoApp/src/main/java/com/example/confidencedemoapp/MainVm.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.spotify.confidence.*
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.util.Date
@@ -48,10 +49,20 @@ class MainVm(app: Application) : AndroidViewModel(app) {
             loggingLevel = LoggingLevel.VERBOSE
         )
         confidence.track(AndroidLifecycleEventProducer(getApplication(), false))
+        confidence.track(
+            ConfidenceDeviceInfoContextProducer(
+                applicationContext = getApplication(),
+                withVersionInfo = true,
+                withBundleId = true,
+                withDeviceInfo = true,
+                withLocale = true
+            )
+        )
+
         eventSender = confidence.withContext(mutableMap)
 
         viewModelScope.launch {
-            if(confidence.isStorageEmpty()) {
+            if (confidence.isStorageEmpty()) {
                 confidence.fetchAndActivate()
             } else {
                 confidence.activate()
@@ -77,8 +88,11 @@ class MainVm(app: Application) : AndroidViewModel(app) {
         }.toComposeColor()
         _message.postValue(messageValue)
         _color.postValue(colorFlag)
-        _surfaceText.postValue(confidence.getContext().entries.map { "${it.key}=${it.value}"}.joinToString { it })
-        eventSender.track("navigate", mapOf("my_date" to ConfidenceValue.Date(Date()), "my_time" to ConfidenceValue.Timestamp(Date())))
+        _surfaceText.postValue(confidence.getContext().entries.map { "${it.key}=${it.value}" }.joinToString { it })
+        eventSender.track(
+            "navigate",
+            mapOf("my_date" to ConfidenceValue.Date(Date()), "my_time" to ConfidenceValue.Timestamp(Date()))
+        )
     }
 
     fun updateContext() {

--- a/ConfidenceDemoApp/src/main/java/com/example/confidencedemoapp/MainVm.kt
+++ b/ConfidenceDemoApp/src/main/java/com/example/confidencedemoapp/MainVm.kt
@@ -52,8 +52,8 @@ class MainVm(app: Application) : AndroidViewModel(app) {
         confidence.track(
             ConfidenceDeviceInfoContextProducer(
                 applicationContext = getApplication(),
-                withVersionInfo = true,
-                withBundleId = true,
+                withAppInfo = true,
+                withOsInfo = true,
                 withDeviceInfo = true,
                 withLocale = true
             )

--- a/README.md
+++ b/README.md
@@ -94,16 +94,19 @@ All `context` data set on the `Confidence` instance will be appended to the even
 confidence.track("button-tapped", mapOf("button_id" to ConfidenceValue.String("purchase_button")))
 ```
 
-The Confidence SDK has support for `EventProducer`. This is a way to programmatically emit context changes and events into streams 
+The Confidence SDK has support for `Producer`s. This is a way for SDK integrators to programmatically emit context changes and events into streams 
 which can be consumed by the SDK to automatically emit events or to automatically update context data.
 
-The Confidence SDK comes with a pre-defined event producer to emit some application lifecycle events: `AndroidLifecycleEventProducer`. To use it:
+The Confidence SDK comes with a pre-defined producer to set some context data: `ConfidenceDeviceInfoContextProducer`. To use it:
 ```kotlin
-import com.spotify.confidence.AndroidLifecycleEventProducer
+import com.spotify.confidence.ConfidenceDeviceInfoContextProducer
 confidence.track(
-    AndroidLifecycleEventProducer(
-        application = getApplication(),
-        trackActivities = false // or true
+    ConfidenceDeviceInfoContextProducer(
+        applicationContext = getApplication(),
+        withAppInfo = true, // defaults to false
+        withOsInfo = true, // defaults to false
+        withDeviceInfo = true, // defaults to false
+        withLocale = true // defaults to false
     )
 )
 ```


### PR DESCRIPTION
The main work here is to stop exposing the `AndroidLifecycleEventProducer` and to restructure how we expose the ?`Producer` interface.
Keeping multiple breaking changes in one PR.