### PR TITLE
fix: skip extra resolve when initialising ConfidenceProvider

### DIFF
--- a/Confidence/api/Confidence.api
+++ b/Confidence/api/Confidence.api
@@ -21,6 +21,7 @@ public final class com/spotify/confidence/Confidence : com/spotify/confidence/Co
 	public fun putContext (Ljava/lang/String;Lcom/spotify/confidence/ConfidenceValue;)V
 	public fun putContext (Ljava/util/Map;)V
 	public final fun putContext (Ljava/util/Map;Ljava/util/List;)V
+	public final fun putContextLocal (Ljava/util/Map;)V
 	public fun removeContext (Ljava/lang/String;)V
 	public fun stop ()V
 	public fun track (Lcom/spotify/confidence/Producer;)V

--- a/Confidence/src/main/java/com/spotify/confidence/Confidence.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/Confidence.kt
@@ -150,6 +150,20 @@ class Confidence internal constructor(
     }
 
     /**
+     * Adds/override entry to local context data only.
+     * Warning: Does not trigger a new flag fetch after the context change.
+     * @param context context to add.
+     */
+    @Synchronized
+    fun putContextLocal(context: Map<String, ConfidenceValue>) {
+        val map = contextMap.value.toMutableMap()
+        map += context
+        contextMap.value = map
+        // No triggering of new flag fetch
+        debugLogger?.logContext("putContextLocal", contextMap.value)
+    }
+
+    /**
      * Check if cache is empty
      */
     fun isStorageEmpty(): Boolean = diskStorage.read() == FlagResolution.EMPTY

--- a/Provider/src/main/java/com/spotify/confidence/openfeature/ConfidenceFeatureProvider.kt
+++ b/Provider/src/main/java/com/spotify/confidence/openfeature/ConfidenceFeatureProvider.kt
@@ -47,7 +47,7 @@ class ConfidenceFeatureProvider private constructor(
 
     override fun initialize(initialContext: EvaluationContext?) {
         initialContext?.toConfidenceContext()?.let {
-            confidence.putContext(it.map)
+            confidence.putContextLocal(it.map)
         }
 
         when (initialisationStrategy) {


### PR DESCRIPTION
API change is only adding a param (and with a default value) so it shouldn't be breaking.