### PR TITLE
chore: move to toml for version catalog

### DIFF
--- a/Confidence/build.gradle.kts
+++ b/Confidence/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("maven-publish")
     id("org.jlleitschuh.gradle.ktlint")
+    id("org.jetbrains.kotlin.plugin.serialization") apply true
     id("signing")
-    kotlin("plugin.serialization").version("1.8.10").apply(true)
     id("org.jetbrains.kotlinx.binary-compatibility-validator")
     id("org.jetbrains.kotlinx.kover")
 }
@@ -52,16 +52,15 @@ android {
 }
 
 dependencies {
-    implementation("com.squareup.okhttp3:okhttp:${Versions.okHttp}")
-    implementation(
-        "org.jetbrains.kotlinx:kotlinx-serialization-json:${Versions.kotlinxSerialization}"
-    )
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}")
-    testImplementation("junit:junit:${Versions.junit}")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.coroutines}")
-    testImplementation("org.mockito.kotlin:mockito-kotlin:${Versions.kotlinMockito}")
-    testImplementation("com.squareup.okhttp3:mockwebserver:${Versions.mockWebServer}")
-    testImplementation("io.mockk:mockk:1.13.11")
+    implementation(libs.okHttp)
+    implementation(libs.kotlinxSerialization)
+    implementation(libs.coroutines)
+    testImplementation(libs.junit)
+    testImplementation(libs.coroutines)
+    testImplementation(libs.kotlinMockito)
+    testImplementation(libs.mockWebServer)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinxCoroutinesTest)
 }
 
 publishing {

--- a/ConfidenceDemoApp/build.gradle.kts
+++ b/ConfidenceDemoApp/build.gradle.kts
@@ -2,26 +2,8 @@ import java.io.File
 import java.util.Properties
 
 plugins {
-    id("com.android.application")
-    id("org.jetbrains.kotlin.android")
-}
-
-object Versions {
-    const val coroutines = "1.7.1"
-    const val liveData = "1.2.0"
-    const val core = "1.7.0"
-    const val lifecycleRuntime = "2.6.1"
-    const val activityCompose = "1.3.1"
-    const val kotlinxSerialization = "1.6.0"
-    const val composeUi = "1.2.0"
-    const val composeUiToolingPreview = "1.2.0"
-    const val composeMaterial = "1.2.0"
-    const val jUnit = "4.13.2"
-    const val jUnitTest = "1.1.3"
-    const val espresso = "3.4.0"
-    const val jUnitUiTest = "1.2.0"
-    const val composeUiTooling = "1.2.0"
-    const val uiTestManifest = "1.2.0"
+    alias(libs.plugins.androidApplication)
+    alias(libs.plugins.kotlinAndroid)
 }
 
 val localPropertiesFile = File(rootProject.projectDir, "local.properties")
@@ -73,7 +55,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.1"
+        kotlinCompilerExtensionVersion = "1.4.2"
     }
     packagingOptions {
         resources {
@@ -84,19 +66,19 @@ android {
 
 dependencies {
     implementation(project(":Confidence"))
-    implementation("androidx.lifecycle:lifecycle-process:2.6.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}")
-    implementation( "androidx.compose.runtime:runtime-livedata:${Versions.liveData}")
-    implementation( "androidx.core:core-ktx:${Versions.core}")
-    implementation( "androidx.lifecycle:lifecycle-runtime-ktx:${Versions.lifecycleRuntime}")
-    implementation( "androidx.activity:activity-compose:${Versions.activityCompose}")
-    implementation( "androidx.compose.ui:ui:${Versions.composeUi}")
-    implementation( "androidx.compose.ui:ui-tooling-preview:${Versions.composeUiToolingPreview}")
-    implementation( "androidx.compose.material:material:${Versions.composeMaterial}")
-    testImplementation( "junit:junit:${Versions.jUnit}")
-    androidTestImplementation( "androidx.test.ext:junit:${Versions.jUnitTest}")
-    androidTestImplementation( "androidx.test.espresso:espresso-core:${Versions.espresso}")
-    androidTestImplementation( "androidx.compose.ui:ui-test-junit4:${Versions.jUnitUiTest}")
-    debugImplementation("androidx.compose.ui:ui-tooling:${Versions.composeUiTooling}")
-    debugImplementation("androidx.compose.ui:ui-test-manifest:${Versions.uiTestManifest}")
+    implementation(libs.lifecycleProcess)
+    implementation(libs.coroutines)
+    implementation(libs.liveData)
+    implementation(libs.core)
+    implementation(libs.lifecycleRuntime)
+    implementation(libs.activityCompose)
+    implementation(libs.composeUi)
+    implementation(libs.composeUiToolingPreview)
+    implementation(libs.composeMaterial)
+    testImplementation(libs.junit)
+    androidTestImplementation(libs.jUnitTest)
+    androidTestImplementation(libs.espresso)
+    androidTestImplementation(libs.jUnitUiTest)
+    debugImplementation(libs.composeUiTooling)
+    debugImplementation(libs.uiTestManifest)
 }

--- a/Provider/build.gradle.kts
+++ b/Provider/build.gradle.kts
@@ -1,23 +1,13 @@
 // ktlint-disable max-line-length
 plugins {
-    id("com.android.library")
-    id("org.jetbrains.kotlin.android")
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.kotlinAndroid)
     id("maven-publish")
-    id("org.jlleitschuh.gradle.ktlint")
-    kotlin("plugin.serialization")
+    alias(libs.plugins.ktlint)
+    alias(libs.plugins.kotlinSerialization) apply true
     id("signing")
-    id("org.jetbrains.kotlinx.binary-compatibility-validator")
-    id("org.jetbrains.kotlinx.kover")
-}
-
-object Versions {
-    const val openFeatureSDK = "0.4.1"
-    const val okHttp = "4.10.0"
-    const val kotlinxSerialization = "1.6.0"
-    const val coroutines = "1.7.3"
-    const val junit = "4.13.2"
-    const val kotlinMockito = "4.1.0"
-    const val mockWebServer = "4.9.1"
+    alias(libs.plugins.binaryCompatibilityValidation)
+    alias(libs.plugins.kover)
 }
 
 val providerVersion = project.extra["version"].toString()
@@ -54,18 +44,17 @@ android {
 }
 
 dependencies {
-    api("dev.openfeature:android-sdk:${Versions.openFeatureSDK}")
-    implementation("com.squareup.okhttp3:okhttp:${Versions.okHttp}")
-    implementation(
-        "org.jetbrains.kotlinx:kotlinx-serialization-json:${Versions.kotlinxSerialization}"
-    )
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}")
+    api(libs.openFeatureSDK)
+    implementation(libs.okHttp)
+    implementation(libs.kotlinxSerialization)
+    implementation(libs.coroutines)
     api(project(":Confidence"))
-    testImplementation("junit:junit:${Versions.junit}")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.coroutines}")
-    testImplementation("org.mockito.kotlin:mockito-kotlin:${Versions.kotlinMockito}")
-    testImplementation("com.squareup.okhttp3:mockwebserver:${Versions.mockWebServer}")
-    testImplementation("io.mockk:mockk:1.13.9")
+    testImplementation(libs.junit)
+    testImplementation(libs.coroutines)
+    testImplementation(libs.kotlinMockito)
+    testImplementation(libs.mockWebServer)
+    testImplementation(libs.kotlinxCoroutinesTest)
+    testImplementation(libs.mockk)
 }
 
 publishing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.library").version("7.4.2").apply(false)
-    id("org.jetbrains.kotlin.android").version("1.8.0").apply(false)
-    id("org.jlleitschuh.gradle.ktlint").version("11.3.2").apply(true)
-    kotlin("plugin.serialization").version("1.8.10").apply(true)
-    id("com.android.application") version "7.4.2" apply false
-    id("io.github.gradle-nexus.publish-plugin").version("1.3.0").apply(true)
-    id("org.jetbrains.kotlinx.binary-compatibility-validator").version("0.17.0").apply(false)
-    id("org.jetbrains.kotlinx.kover").version("0.8.2").apply(true)
+    alias(libs.plugins.androidLibrary) apply false
+    alias(libs.plugins.kotlinAndroid) apply false
+    alias(libs.plugins.ktlint) apply true
+    alias(libs.plugins.kotlinSerialization) apply true
+    alias(libs.plugins.androidApplication) apply false
+    alias(libs.plugins.nexusPublish) apply true
+    alias(libs.plugins.binaryCompatibilityValidation) apply false
+    alias(libs.plugins.kover) apply true
 }
 
 allprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,65 +1,56 @@
 [versions]
 activityCompose = "1.3.1"
-androidApplication = "7.4.2"
-androidLibrary = "7.4.2"
+androidGradlePlugin = "7.4.2"
+androidXJunitTest = "1.1.3"
+binaryCompatibilityValidation = "0.11.0"
+composeUi = "1.2.0"
 core = "1.7.0"
 coroutines = "1.7.3"
 espresso = "3.4.0"
-jUnitTest = "1.1.3"
-jUnitUiTest = "1.2.0"
 junit = "4.13.2"
 kotlinAndroid = "1.8.10"
 kotlinMockito = "4.1.0"
-kotlinSerialization = "1.8.10"
-kotlinxCoroutinesTest = "1.7.3"
 kotlinxSerialization = "1.6.0"
 kover = "0.8.2"
-lifecycleProcess = "2.6.1"
-lifecycleRuntime = "2.6.1"
+lifecycle = "2.6.1"
 liveData = "1.2.0"
 mockWebServer = "4.9.1"
 nexusPublish = "1.3.0"
 okHttp = "4.10.0"
 openFeatureSDK = "0.4.1"
-uiTestManifest = "1.2.0"
-composeUi = "1.2.0"
-composeUiTooling = "1.2.0"
-composeUiToolingPreview = "1.2.0"
-composeMaterial = "1.2.0"
-binaryCompatibilityValidation = "0.11.0"
 ktlint = "11.3.2"
 mockk = "1.13.11"
 
 [libraries]
 activityCompose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
-composeMaterial = { group = "androidx.compose.material", name = "material", version.ref = "composeMaterial" }
+composeMaterial = { group = "androidx.compose.material", name = "material", version.ref = "composeUi" }
 composeUi = { group = "androidx.compose.ui", name = "ui", version.ref = "composeUi" }
-composeUiTooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "composeUiTooling" }
-composeUiToolingPreview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "composeUiToolingPreview" }
+composeUiTooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "composeUi" }
+composeUiToolingPreview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "composeUi" }
 core = { group = "androidx.core", name = "core-ktx", version.ref = "core" }
 coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 espresso = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }
-jUnitTest = { group = "androidx.test.ext", name = "junit", version.ref = "jUnitTest" }
-jUnitUiTest = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "jUnitUiTest" }
+jUnitTest = { group = "androidx.test.ext", name = "junit", version.ref = "androidXJunitTest" }
+jUnitUiTest = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "composeUi" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlinMockito = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "kotlinMockito" }
-kotlinxCoroutinesTest = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+kotlinxCoroutinesTest = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinxSerialization = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
-lifecycleProcess = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycleProcess" }
-lifecycleRuntime = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntime" }
+lifecycleProcess = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
+lifecycleRuntime = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 liveData = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "liveData" }
 mockWebServer = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "mockWebServer" }
 okHttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okHttp" }
 openFeatureSDK = { group = "dev.openfeature", name = "android-sdk", version.ref = "openFeatureSDK" }
-uiTestManifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "uiTestManifest" }
+uiTestManifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "composeUi" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 
 [plugins]
-androidApplication = { id = "com.android.application", version.ref = "androidApplication" }
-androidLibrary = { id = "com.android.library", version.ref = "androidLibrary" }
+androidApplication = { id = "com.android.application", version.ref = "androidGradlePlugin" }
+androidLibrary = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 binaryCompatibilityValidation = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryCompatibilityValidation" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinAndroid" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
-kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinSerialization" }
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinAndroid" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublish" } 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,65 @@
+[versions]
+activityCompose = "1.3.1"
+androidApplication = "7.4.2"
+androidLibrary = "7.4.2"
+core = "1.7.0"
+coroutines = "1.7.3"
+espresso = "3.4.0"
+jUnitTest = "1.1.3"
+jUnitUiTest = "1.2.0"
+junit = "4.13.2"
+kotlinAndroid = "1.8.10"
+kotlinMockito = "4.1.0"
+kotlinSerialization = "1.8.10"
+kotlinxCoroutinesTest = "1.7.3"
+kotlinxSerialization = "1.6.0"
+kover = "0.8.2"
+lifecycleProcess = "2.6.1"
+lifecycleRuntime = "2.6.1"
+liveData = "1.2.0"
+mockWebServer = "4.9.1"
+nexusPublish = "1.3.0"
+okHttp = "4.10.0"
+openFeatureSDK = "0.4.1"
+uiTestManifest = "1.2.0"
+composeUi = "1.2.0"
+composeUiTooling = "1.2.0"
+composeUiToolingPreview = "1.2.0"
+composeMaterial = "1.2.0"
+binaryCompatibilityValidation = "0.11.0"
+ktlint = "11.3.2"
+mockk = "1.13.11"
+
+[libraries]
+activityCompose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+composeMaterial = { group = "androidx.compose.material", name = "material", version.ref = "composeMaterial" }
+composeUi = { group = "androidx.compose.ui", name = "ui", version.ref = "composeUi" }
+composeUiTooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "composeUiTooling" }
+composeUiToolingPreview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "composeUiToolingPreview" }
+core = { group = "androidx.core", name = "core-ktx", version.ref = "core" }
+coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
+espresso = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }
+jUnitTest = { group = "androidx.test.ext", name = "junit", version.ref = "jUnitTest" }
+jUnitUiTest = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "jUnitUiTest" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+kotlinMockito = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "kotlinMockito" }
+kotlinxCoroutinesTest = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+kotlinxSerialization = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+lifecycleProcess = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycleProcess" }
+lifecycleRuntime = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntime" }
+liveData = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "liveData" }
+mockWebServer = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "mockWebServer" }
+okHttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okHttp" }
+openFeatureSDK = { group = "dev.openfeature", name = "android-sdk", version.ref = "openFeatureSDK" }
+uiTestManifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "uiTestManifest" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+
+[plugins]
+androidApplication = { id = "com.android.application", version.ref = "androidApplication" }
+androidLibrary = { id = "com.android.library", version.ref = "androidLibrary" }
+binaryCompatibilityValidation = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryCompatibilityValidation" }
+kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinAndroid" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinSerialization" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
+nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublish" } 


### PR DESCRIPTION
This PR migrates our monorepo to adopt the TOML Version Catalog approach for managing dependencies, plugins, and version numbers. By leveraging the Version Catalog feature we aim to improve dependency management, promote consistency across modules, and streamline dependency updates. ✨✨✨