### PR TITLE
feat: configurable visitor id key

### DIFF
--- a/Confidence/src/main/java/com/spotify/confidence/Confidence.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/Confidence.kt
@@ -347,6 +347,7 @@ object ConfidenceFactory {
      * @param dispatcher coroutine dispatcher.
      * @param loggingLevel allows to print warnings or debugging information to the local console.
      * @param timeoutMillis sets a timeout for completing an HTTP call. Defaults to 10 seconds
+     * @param visitorIdContextKey key to use for the visitor id in the context. Defaults to "visitor_id".
      */
     fun create(
         context: Context,
@@ -355,7 +356,8 @@ object ConfidenceFactory {
         region: ConfidenceRegion = ConfidenceRegion.GLOBAL,
         dispatcher: CoroutineDispatcher = Dispatchers.IO,
         loggingLevel: LoggingLevel = LoggingLevel.WARN,
-        timeoutMillis: Long = 10000
+        timeoutMillis: Long = 10000,
+        visitorIdContextKey: String = VISITOR_ID_CONTEXT_KEY
     ): Confidence {
         val debugLogger: DebugLogger? = if (loggingLevel == LoggingLevel.NONE) {
             null
@@ -387,9 +389,12 @@ object ConfidenceFactory {
             sdkMetadata = SdkMetadata(SDK_ID, BuildConfig.SDK_VERSION),
             debugLogger = debugLogger
         )
-        val visitorId = ConfidenceValue.String(VisitorUtil.getId(context))
+
         val initContext = initialContext.toMutableMap()
-        initContext[VISITOR_ID_CONTEXT_KEY] = visitorId
+        if (!initContext.containsKey(visitorIdContextKey)) {
+            debugLogger?.logMessage("Adding visitor id to context with key: $visitorIdContextKey")
+            initContext[visitorIdContextKey] = ConfidenceValue.String(VisitorUtil.getId(context))
+        }
         debugLogger?.logContext("InitialContext", initContext)
 
         return Confidence(

--- a/Confidence/src/test/java/com/spotify/confidence/ConfidenceContextualTests.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/ConfidenceContextualTests.kt
@@ -1,11 +1,63 @@
 package com.spotify.confidence
 
+import android.content.Context
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.nio.file.Files
 
 class ConfidenceContextualTests {
+
+    private val mockContext: Context = mock()
+
+    @get:Rule
+    var tmpFile = TemporaryFolder()
+
+    @Before
+    fun setup() {
+        whenever(mockContext.filesDir).thenReturn(Files.createTempDirectory("tmpTests").toFile())
+        whenever(mockContext.getDir(any(), any())).thenReturn(Files.createTempDirectory("events").toFile())
+        whenever(mockContext.getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)).thenReturn(InMemorySharedPreferences())
+    }
+
+    @Test
+    fun created_confidence_respects_custom_visitor_id_key() = runTest {
+        val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+        val confidence = ConfidenceFactory.create(
+            mockContext,
+            "clientSecret",
+            dispatcher = testDispatcher,
+            visitorIdContextKey = "custom_visitor_id"
+        )
+        val context = confidence.getContext()
+        Assert.assertNotNull(context)
+        Assert.assertTrue(context.containsKey("custom_visitor_id"))
+        Assert.assertFalse(context.containsKey(VISITOR_ID_CONTEXT_KEY))
+    }
+
+    @Test
+    fun created_confidence_respects_pre_set_visitor_id() = runTest {
+        val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+        val confidence = ConfidenceFactory.create(
+            mockContext,
+            "clientSecret",
+            dispatcher = testDispatcher,
+            initialContext = mapOf(VISITOR_ID_CONTEXT_KEY to ConfidenceValue.String("my_visitor_id"))
+        )
+        val context = confidence.getContext()
+        Assert.assertNotNull(context)
+        Assert.assertTrue(context.containsKey(VISITOR_ID_CONTEXT_KEY))
+        Assert.assertEquals("my_visitor_id", context[VISITOR_ID_CONTEXT_KEY].toString())
+    }
+
     @Test
     fun test_forking_context_works() {
         val debugLogger = DebugLoggerFake()


### PR DESCRIPTION
With this change you can decide the visitor ID context key that the SDK will use.
The SDK will also respect if you pass an initial context that already has the (potentially custom) visitor id key and not overwrite it.