### PR TITLE
perf: O(1) flag lookup during evaluation

### DIFF
--- a/Confidence/src/main/java/com/spotify/confidence/ConfidenceFlagEvaluation.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/ConfidenceFlagEvaluation.kt
@@ -17,7 +17,7 @@ fun <T> FlagResolution?.getEvaluation(
         )
     }
     requireNotNull(this)
-    val resolvedFlag = this.flags.firstOrNull { it.flag == parsedKey.flagName }
+    val resolvedFlag = this.resolvedFlag(parsedKey.flagName)
         ?: return Evaluation(
             value = defaultValue,
             reason = ResolveReason.ERROR,

--- a/Confidence/src/main/java/com/spotify/confidence/FlagEvaluator.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/FlagEvaluator.kt
@@ -19,6 +19,15 @@ data class FlagResolution(
     val flags: List<ResolvedFlag>,
     val resolveToken: String
 ) {
+    // O(1) lookup index built once per resolution and queried on every evaluation.
+    // Declared in the class body (not the primary constructor) so it is excluded
+    // from kotlinx.serialization, equals/hashCode/toString and copy().
+    private val flagIndex: Map<String, ResolvedFlag> by lazy {
+        flags.associateBy { it.flag }
+    }
+
+    fun resolvedFlag(name: String): ResolvedFlag? = flagIndex[name]
+
     companion object {
         val EMPTY = FlagResolution(mapOf(), listOf(), "")
     }


### PR DESCRIPTION
## Summary

Replaces the linear `flags.firstOrNull { it.flag == name }` scan in `getEvaluation` with an O(1) dictionary lookup keyed by flag name.

`FlagResolution` now exposes a lazy `flagIndex: Map<String, ResolvedFlag>` that is built once per resolution and queried on every evaluation. Because the property is declared in the class body (not the primary constructor), it is excluded from kotlinx-serialization, `equals` / `hashCode` / `toString`, and `copy()`. The on-disk JSON format is unchanged.

For the 950-flag load-test client this drops per-evaluation lookup from O(n) (~475 string comparisons on average) to O(1). This mirrors the same change we just shipped on the Swift SDK ([confidence-sdk-swift#246](https://github.com/spotify/confidence-sdk-swift/pull/246)).

## Investigation context

This is the second of two perf PRs from the Android-SDK investigation done with the same load-test client (`swift-load-test-950`, 950 flags) we used for the Swift SDK. We instrumented the SDK with debug logging on the resolve hot path and ran the demo app on a Pixel 9a emulator.

### Bottlenecks identified

1. **Wasteful JSON round-trips in `Serializers.kt`** (sister PR #239). Biggest single perf win — closes the cold-launch cliff at high flag counts (4–5 s → ~850 ms on fresh-JVM warm runs at 950 flags) and picks up ~24% on steady-state same-session re-resolves.
2. **O(n) linear flag lookup on every evaluation** — addressed by this PR.
3. **On-disk cache uses verbose polymorphic `ConfidenceValue` envelopes** (491 KB on Android vs 152 KB on Swift for the same data). Tracked as future work; needs a versioned migration.
4. `activate()` contention — *not* a problem on Android: the in-memory cache is a single `@Volatile` reference (no blocking lock, unlike Swift's `DispatchQueue.sync` Swift PR #245 had to fix).

This PR is the smallest of the three. The benefit doesn't show up in the resolve / save / load timers — it only matters when host code reads many flag values per resolution. For 950 flags, every `flag` property read scans on average 475 entries before this fix; afterwards it's one map lookup.

## Why a body property and not a constructor field

`FlagResolution` is `@Serializable`, and its disk format is `Json.encodeToString(flagResolution)`. Putting `flagIndex` in the primary constructor would either need it serialized (bloating the on-disk format) or annotated `@kotlinx.serialization.Transient` with a default value that doesn't depend on `flags` (so the index would be empty after `decodeFromString`). Declaring `flagIndex` in the class body as `by lazy { flags.associateBy { it.flag } }`:

- is not part of the primary constructor, so kotlinx-serialization ignores it on both encode and decode,
- is excluded from `equals` / `hashCode` / `toString` and `copy()` (data-class semantics),
- is computed on first access on whichever instance — including instances reconstructed from disk.

## Test plan

- [x] `./gradlew :Confidence:compileDebugKotlin`
- [x] `./gradlew :Provider:testDebugUnitTest` (the test target CI runs)
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew assembleDebug`
- [x] On-device verification with the 950-flag load-test client on a Pixel 9a emulator: resolve / save / load / read-flag flow exercised; on-disk cache size unchanged.