### PR TITLE
feat: report STATUS_OFFLINE for network connectivity errors

### DIFF
--- a/Confidence/src/main/java/com/spotify/confidence/RemoteFlagResolver.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/RemoteFlagResolver.kt
@@ -17,7 +17,9 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import java.net.NoRouteToHostException
 import java.net.SocketTimeoutException
+import java.net.UnknownHostException
 
 internal interface FlagResolver {
     suspend fun resolve(flags: List<String>, context: Map<String, ConfidenceValue>): Result<FlagResolution>
@@ -64,6 +66,12 @@ internal class RemoteFlagResolver(
                 throw e
             } catch (e: SocketTimeoutException) {
                 status = Telemetry.RequestStatus.TIMEOUT
+                throw e
+            } catch (e: UnknownHostException) {
+                status = Telemetry.RequestStatus.OFFLINE
+                throw e
+            } catch (e: NoRouteToHostException) {
+                status = Telemetry.RequestStatus.OFFLINE
                 throw e
             } catch (e: Exception) {
                 status = Telemetry.RequestStatus.ERROR

--- a/Confidence/src/main/java/com/spotify/confidence/Telemetry.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/Telemetry.kt
@@ -239,7 +239,8 @@ internal class Telemetry(
         UNSPECIFIED(0),
         SUCCESS(1),
         ERROR(2),
-        TIMEOUT(3)
+        TIMEOUT(3),
+        OFFLINE(5)
     }
 
     enum class EvaluationReason(val value: Int) {

--- a/Confidence/src/test/java/com/spotify/confidence/ConfidenceRemoteClientTests.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/ConfidenceRemoteClientTests.kt
@@ -1201,6 +1201,47 @@ internal class ConfidenceRemoteClientTests {
     }
 
     @Test
+    fun testOfflineResolveTracksTelemetryAsOffline() = runTest {
+        val tel = Telemetry("", Telemetry.Library.CONFIDENCE, "")
+
+        val resolver = RemoteFlagResolver(
+            clientSecret = "",
+            region = ConfidenceRegion.EUROPE,
+            baseUrl = okhttp3.HttpUrl.Builder()
+                .scheme("http")
+                .host("host.invalid")
+                .port(1)
+                .build(),
+            dispatcher = Dispatchers.IO,
+            httpClient = OkHttpClient.Builder()
+                .dns(object : okhttp3.Dns {
+                    override fun lookup(hostname: String): List<java.net.InetAddress> {
+                        throw java.net.UnknownHostException(hostname)
+                    }
+                })
+                .build(),
+            telemetry = tel
+        )
+
+        try {
+            resolver.resolve(listOf(), mapOf())
+        } catch (_: java.net.UnknownHostException) {
+            // expected
+        }
+
+        val headerValue = tel.encodedHeaderValue()
+        assertNotNull(
+            "Offline resolve should produce a telemetry trace",
+            headerValue
+        )
+
+        val bytes = java.util.Base64.getDecoder().decode(headerValue!!)
+        val monitoring = Monitoring.parseFrom(bytes)
+        val trace = monitoring.getLibraryTraces(0).tracesList.first()
+        assertEquals(ProtoStatus.STATUS_OFFLINE, trace.requestTrace.status)
+    }
+
+    @Test
     fun testApplyReturnsFailureAfter500() = runTest {
         val testDispatcher = UnconfinedTestDispatcher(testScheduler)
         val applyDate = Date.from(Instant.parse("2023-03-01T14:01:46.123Z"))

--- a/Confidence/src/test/proto/confidence/telemetry/v1/types.proto
+++ b/Confidence/src/test/proto/confidence/telemetry/v1/types.proto
@@ -50,6 +50,7 @@ message LibraryTraces {
         STATUS_ERROR = 2;
         STATUS_TIMEOUT = 3;
         STATUS_CACHED = 4;
+        STATUS_OFFLINE = 5;
       }
     }
 


### PR DESCRIPTION
## Summary

- Adds `STATUS_OFFLINE` (value 5) to the telemetry `RequestStatus` enum and the test proto
- Catches `UnknownHostException` and `NoRouteToHostException` in `RemoteFlagResolver` and reports them as `STATUS_OFFLINE` instead of `STATUS_ERROR`
- This lets us distinguish genuine SDK errors from expected offline scenarios (airplane mode, no Wi-Fi/cellular) in production metrics

## Notes

- Stacked on #242 (CancellationException fix). Merge #242 first, then rebase this onto `main`.
- **No backend changes needed** — the `epx-flags-resolver` Prometheus interceptor derives metric labels from the proto enum `.name()`, so `STATUS_OFFLINE` will appear automatically as a new label value.

## Test plan

- [x] New unit test `testOfflineResolveTracksTelemetryAsOffline` verifies that DNS failure produces `STATUS_OFFLINE` in the telemetry header
- [x] Full test suite passes


Made with [Cursor](https://cursor.com)