### PR TITLE
feat: migrate integration tests to new Confidence workspace

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,8 @@ jobs:
       - name: Run build debug
         run: ./gradlew assembleDebug
       - name: Run Tests
+        env:
+          CONFIDENCE_CLIENT_SECRET: ${{ secrets.CONFIDENCE_CLIENT_SECRET }}
         run: ./gradlew :Provider:testDebugUnitTest --no-daemon --stacktrace --info
       - name: Run build release
         run: ./gradlew assembleRelease

--- a/Confidence/src/test/java/com/spotify/confidence/ConfidenceIntegrationTests.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/ConfidenceIntegrationTests.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import com.spotify.confidence.cache.FileDiskStorage
 import com.spotify.confidence.client.ResolvedFlag
 import org.junit.Assert
+import org.junit.Assume
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -15,7 +16,7 @@ import org.mockito.kotlin.whenever
 import java.nio.file.Files
 import java.util.UUID
 
-private const val clientSecret = "21wxcxXpU6tKBRFtEFTXYiH7nDqL86Mm"
+private val clientSecret = System.getenv("CONFIDENCE_CLIENT_SECRET") ?: ""
 private val mockContext: Context = mock()
 
 class ConfidenceIntegrationTests {
@@ -25,6 +26,7 @@ class ConfidenceIntegrationTests {
 
     @Before
     fun setup() {
+        Assume.assumeTrue("CONFIDENCE_CLIENT_SECRET not set, skipping integration tests", clientSecret.isNotEmpty())
         whenever(mockContext.filesDir).thenReturn(Files.createTempDirectory("tmpTests").toFile())
         whenever(mockContext.getDir(any(), any())).thenReturn(Files.createTempDirectory("events").toFile())
         whenever(mockContext.getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)).thenReturn(InMemorySharedPreferences())

--- a/Confidence/src/test/java/com/spotify/confidence/EventSenderIntegrationTest.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/EventSenderIntegrationTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
+import org.junit.Assume
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -19,7 +20,7 @@ import org.mockito.kotlin.whenever
 import java.io.File
 import java.nio.file.Files
 
-private const val clientSecret = "WciJVLIEiNnRxV8gaYPZNCFF8vbAXOu6"
+private val clientSecret = System.getenv("CONFIDENCE_CLIENT_SECRET") ?: ""
 private val mockContext: Context = mock()
 private val mockSharedPrefs: SharedPreferences = mock()
 private val mockSharedPrefsEdit: SharedPreferences.Editor = mock()
@@ -32,6 +33,7 @@ class EventSenderIntegrationTest {
 
     @Before
     fun setup() {
+        Assume.assumeTrue("CONFIDENCE_CLIENT_SECRET not set, skipping integration tests", clientSecret.isNotEmpty())
         whenever(mockContext.getDir("events", Context.MODE_PRIVATE)).thenReturn(directory)
         whenever(mockContext.getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)).thenReturn(mockSharedPrefs)
         whenever(mockSharedPrefs.edit()).thenReturn(mockSharedPrefsEdit)

--- a/Provider/src/test/java/com/spotify/confidence/openfeature/ProviderIntegrationTest.kt
+++ b/Provider/src/test/java/com/spotify/confidence/openfeature/ProviderIntegrationTest.kt
@@ -30,6 +30,7 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Assume
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -41,7 +42,7 @@ import java.io.File
 import java.nio.file.Files
 import java.util.UUID
 
-private const val clientSecret = "21wxcxXpU6tKBRFtEFTXYiH7nDqL86Mm"
+private val clientSecret = System.getenv("CONFIDENCE_CLIENT_SECRET") ?: ""
 private val mockContext: Context = mock()
 
 class ProviderIntegrationTest {
@@ -53,6 +54,7 @@ class ProviderIntegrationTest {
 
     @Before
     fun setup() = runTest(UnconfinedTestDispatcher()) {
+        Assume.assumeTrue("CONFIDENCE_CLIENT_SECRET not set, skipping integration tests", clientSecret.isNotEmpty())
         mockkStatic(Log::class)
         every { Log.d(any(), any()) } answers {
             println("DEBUG: ${arg<String>(1)}")


### PR DESCRIPTION
## Summary
- Read client secret from `CONFIDENCE_CLIENT_SECRET` env var instead of hardcoding
- Tests skip gracefully via `Assume` when secret is unavailable
- CI workflow injects the secret from GitHub Actions secrets

## After merging
Add repo secret `CONFIDENCE_CLIENT_SECRET` via GitHub Settings (already done via `gh secret set`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)