### PR TITLE
chore: fail loudly on missing CONFIDENCE_CLIENT_SECRET

### DIFF
--- a/Confidence/src/test/java/com/spotify/confidence/ConfidenceIntegrationTests.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/ConfidenceIntegrationTests.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import com.spotify.confidence.cache.FileDiskStorage
 import com.spotify.confidence.client.ResolvedFlag
 import org.junit.Assert
-import org.junit.Assume
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -16,7 +15,7 @@ import org.mockito.kotlin.whenever
 import java.nio.file.Files
 import java.util.UUID
 
-private val clientSecret = System.getenv("CONFIDENCE_CLIENT_SECRET") ?: ""
+private val clientSecret = System.getenv("CONFIDENCE_CLIENT_SECRET")!!
 private val mockContext: Context = mock()
 
 class ConfidenceIntegrationTests {
@@ -26,7 +25,6 @@ class ConfidenceIntegrationTests {
 
     @Before
     fun setup() {
-        Assume.assumeTrue("CONFIDENCE_CLIENT_SECRET not set, skipping integration tests", clientSecret.isNotEmpty())
         whenever(mockContext.filesDir).thenReturn(Files.createTempDirectory("tmpTests").toFile())
         whenever(mockContext.getDir(any(), any())).thenReturn(Files.createTempDirectory("events").toFile())
         whenever(mockContext.getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)).thenReturn(InMemorySharedPreferences())

--- a/Confidence/src/test/java/com/spotify/confidence/EventSenderIntegrationTest.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/EventSenderIntegrationTest.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
-import org.junit.Assume
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -20,7 +19,7 @@ import org.mockito.kotlin.whenever
 import java.io.File
 import java.nio.file.Files
 
-private val clientSecret = System.getenv("CONFIDENCE_CLIENT_SECRET") ?: ""
+private val clientSecret = System.getenv("CONFIDENCE_CLIENT_SECRET")!!
 private val mockContext: Context = mock()
 private val mockSharedPrefs: SharedPreferences = mock()
 private val mockSharedPrefsEdit: SharedPreferences.Editor = mock()
@@ -33,7 +32,6 @@ class EventSenderIntegrationTest {
 
     @Before
     fun setup() {
-        Assume.assumeTrue("CONFIDENCE_CLIENT_SECRET not set, skipping integration tests", clientSecret.isNotEmpty())
         whenever(mockContext.getDir("events", Context.MODE_PRIVATE)).thenReturn(directory)
         whenever(mockContext.getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)).thenReturn(mockSharedPrefs)
         whenever(mockSharedPrefs.edit()).thenReturn(mockSharedPrefsEdit)

--- a/Provider/src/test/java/com/spotify/confidence/openfeature/ProviderIntegrationTest.kt
+++ b/Provider/src/test/java/com/spotify/confidence/openfeature/ProviderIntegrationTest.kt
@@ -30,7 +30,6 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Assume
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -42,7 +41,7 @@ import java.io.File
 import java.nio.file.Files
 import java.util.UUID
 
-private val clientSecret = System.getenv("CONFIDENCE_CLIENT_SECRET") ?: ""
+private val clientSecret = System.getenv("CONFIDENCE_CLIENT_SECRET")!!
 private val mockContext: Context = mock()
 
 class ProviderIntegrationTest {
@@ -54,7 +53,6 @@ class ProviderIntegrationTest {
 
     @Before
     fun setup() = runTest(UnconfinedTestDispatcher()) {
-        Assume.assumeTrue("CONFIDENCE_CLIENT_SECRET not set, skipping integration tests", clientSecret.isNotEmpty())
         mockkStatic(Log::class)
         every { Log.d(any(), any()) } answers {
             println("DEBUG: ${arg<String>(1)}")


### PR DESCRIPTION
## Summary
- Remove `Assume` skip guards from integration tests
- Tests now fail loudly if `CONFIDENCE_CLIENT_SECRET` env var is missing

Follow-up to #248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)