### PR TITLE
ci: update release-please-action from v3 to v4.1.1

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -14,12 +14,10 @@ jobs:
 
     # Release-please creates a PR that tracks all changes
     steps:
-      - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3
+      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
         id: release
         with:
-          release-type: simple
-          command: manifest
-          default-branch: main
+          target-branch: main
 
       - name: Dump Release Please Output
         env:


### PR DESCRIPTION
## Summary
- Update `google-github-actions/release-please-action` from v3 to v4.1.1 (Node.js 20 actions are deprecated starting June 16, 2026)
- Remove `command: manifest` input (v4 defaults to manifest mode when `release-type` is unset)
- Remove `release-type: simple` from workflow (already defined in `release-please-config.json`)
- Rename `default-branch` → `target-branch`

## Test plan
- [ ] Verify the release-please PR is created correctly on the next push to `main`
- [ ] Verify release outputs (`release_created`, `release_tag_name`) still propagate to the `kotlin-release` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)