### PR TITLE
feat: OpenFeature track and event delivery reliability

### DIFF
--- a/Confidence/api/Confidence.api
+++ b/Confidence/api/Confidence.api
@@ -111,10 +111,10 @@ public final class com/spotify/confidence/ConfidenceError$ParseError : java/lang
 
 public final class com/spotify/confidence/ConfidenceFactory {
 	public static final field INSTANCE Lcom/spotify/confidence/ConfidenceFactory;
-	public final fun create (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/spotify/confidence/ConfidenceRegion;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/spotify/confidence/LoggingLevel;JLjava/lang/String;)Lcom/spotify/confidence/Confidence;
-	public final fun create (Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Lcom/spotify/confidence/ConfidenceRegion;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/spotify/confidence/LoggingLevel;JLjava/lang/String;)Lcom/spotify/confidence/Confidence;
-	public static synthetic fun create$default (Lcom/spotify/confidence/ConfidenceFactory;Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/spotify/confidence/ConfidenceRegion;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/spotify/confidence/LoggingLevel;JLjava/lang/String;ILjava/lang/Object;)Lcom/spotify/confidence/Confidence;
-	public static synthetic fun create$default (Lcom/spotify/confidence/ConfidenceFactory;Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Lcom/spotify/confidence/ConfidenceRegion;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/spotify/confidence/LoggingLevel;JLjava/lang/String;ILjava/lang/Object;)Lcom/spotify/confidence/Confidence;
+	public final fun create (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/spotify/confidence/ConfidenceRegion;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/spotify/confidence/LoggingLevel;JLjava/lang/String;Ljava/lang/Long;)Lcom/spotify/confidence/Confidence;
+	public final fun create (Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Lcom/spotify/confidence/ConfidenceRegion;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/spotify/confidence/LoggingLevel;JLjava/lang/String;Ljava/lang/Long;)Lcom/spotify/confidence/Confidence;
+	public static synthetic fun create$default (Lcom/spotify/confidence/ConfidenceFactory;Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/spotify/confidence/ConfidenceRegion;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/spotify/confidence/LoggingLevel;JLjava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lcom/spotify/confidence/Confidence;
+	public static synthetic fun create$default (Lcom/spotify/confidence/ConfidenceFactory;Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Lcom/spotify/confidence/ConfidenceRegion;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/spotify/confidence/LoggingLevel;JLjava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lcom/spotify/confidence/Confidence;
 }
 
 public final class com/spotify/confidence/ConfidenceFlagEvaluationKt {

--- a/Confidence/api/Confidence.api
+++ b/Confidence/api/Confidence.api
@@ -19,6 +19,7 @@ public final class com/spotify/confidence/Confidence : com/spotify/confidence/Co
 	public fun stop ()V
 	public fun track (Lcom/spotify/confidence/Producer;)V
 	public fun track (Ljava/lang/String;Ljava/util/Map;)V
+	public fun track (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
 	public synthetic fun withContext (Ljava/util/Map;)Lcom/spotify/confidence/Contextual;
 	public fun withContext (Ljava/util/Map;)Lcom/spotify/confidence/EventSender;
 }
@@ -407,6 +408,7 @@ public abstract interface class com/spotify/confidence/EventSender : com/spotify
 	public abstract fun stop ()V
 	public abstract fun track (Lcom/spotify/confidence/Producer;)V
 	public abstract fun track (Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun track (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
 	public abstract fun withContext (Ljava/util/Map;)Lcom/spotify/confidence/EventSender;
 }
 

--- a/Confidence/src/main/java/com/spotify/confidence/Confidence.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/Confidence.kt
@@ -385,6 +385,7 @@ object ConfidenceFactory {
      * @param loggingLevel allows to print warnings or debugging information to the local console.
      * @param timeoutMillis sets a timeout for completing an HTTP call. Defaults to 10 seconds
      * @param visitorIdContextKey key to use for the visitor id in the context. Defaults to "visitor_id".
+     * @param eventFlushIntervalMillis optional periodic flush interval in milliseconds. Disabled by default.
      */
     fun create(
         context: Context,
@@ -394,7 +395,8 @@ object ConfidenceFactory {
         dispatcher: CoroutineDispatcher = Dispatchers.IO,
         loggingLevel: LoggingLevel = LoggingLevel.WARN,
         timeoutMillis: Long = 10000,
-        visitorIdContextKey: String = VISITOR_ID_CONTEXT_KEY
+        visitorIdContextKey: String = VISITOR_ID_CONTEXT_KEY,
+        eventFlushIntervalMillis: Long? = null
     ): Confidence = create(
         context = context,
         clientSecret = clientSecret,
@@ -404,7 +406,8 @@ object ConfidenceFactory {
         loggingLevel = loggingLevel,
         timeoutMillis = timeoutMillis,
         visitorIdContextKey = visitorIdContextKey,
-        resolveBaseUrl = null
+        resolveBaseUrl = null,
+        eventFlushIntervalMillis = eventFlushIntervalMillis
     )
 
     /**
@@ -421,7 +424,8 @@ object ConfidenceFactory {
         dispatcher: CoroutineDispatcher = Dispatchers.IO,
         loggingLevel: LoggingLevel = LoggingLevel.WARN,
         timeoutMillis: Long = 10000,
-        visitorIdContextKey: String = VISITOR_ID_CONTEXT_KEY
+        visitorIdContextKey: String = VISITOR_ID_CONTEXT_KEY,
+        eventFlushIntervalMillis: Long? = null
     ): Confidence = create(
         context = context,
         clientSecret = clientSecret,
@@ -431,7 +435,8 @@ object ConfidenceFactory {
         loggingLevel = loggingLevel,
         timeoutMillis = timeoutMillis,
         visitorIdContextKey = visitorIdContextKey,
-        resolveBaseUrl = getResolveBaseUrl(region, resolveBaseUrl)
+        resolveBaseUrl = getResolveBaseUrl(region, resolveBaseUrl),
+        eventFlushIntervalMillis = eventFlushIntervalMillis
     )
 
     private fun create(
@@ -443,7 +448,8 @@ object ConfidenceFactory {
         loggingLevel: LoggingLevel,
         timeoutMillis: Long,
         visitorIdContextKey: String,
-        resolveBaseUrl: HttpUrl?
+        resolveBaseUrl: HttpUrl?,
+        eventFlushIntervalMillis: Long? = null
     ): Confidence {
         val debugLogger: DebugLogger? = if (loggingLevel == LoggingLevel.NONE) {
             null
@@ -458,7 +464,8 @@ object ConfidenceFactory {
             flushPolicies = listOf(minBatchSizeFlushPolicy),
             sdkMetadata = sdkMetadata,
             dispatcher = dispatcher,
-            debugLogger = debugLogger
+            debugLogger = debugLogger,
+            flushIntervalMillis = eventFlushIntervalMillis
         )
         val flagApplierClient = FlagApplierClientImpl(
             clientSecret,

--- a/Confidence/src/main/java/com/spotify/confidence/Confidence.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/Confidence.kt
@@ -451,6 +451,9 @@ object ConfidenceFactory {
         resolveBaseUrl: HttpUrl?,
         eventFlushIntervalMillis: Long? = null
     ): Confidence {
+        require(eventFlushIntervalMillis == null || eventFlushIntervalMillis > 0) {
+            "eventFlushIntervalMillis must be positive, or null to disable periodic flushing"
+        }
         val debugLogger: DebugLogger? = if (loggingLevel == LoggingLevel.NONE) {
             null
         } else {

--- a/Confidence/src/main/java/com/spotify/confidence/Confidence.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/Confidence.kt
@@ -254,7 +254,15 @@ class Confidence internal constructor(
         eventName: String,
         data: ConfidenceFieldsType
     ) {
-        eventSenderEngine.emit(eventName, data, getContext())
+        track(eventName, data, getContext())
+    }
+
+    override fun track(
+        eventName: String,
+        data: ConfidenceFieldsType,
+        eventContext: Map<String, ConfidenceValue>
+    ) {
+        eventSenderEngine.emit(eventName, data, eventContext)
     }
 
     override fun flush() {

--- a/Confidence/src/main/java/com/spotify/confidence/ConfidenceError.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/ConfidenceError.kt
@@ -27,5 +27,9 @@ class ConfidenceError {
         override val message: String
     ) : Error(message)
 
+    @Deprecated(
+        "No longer thrown: a 'context' field in event data now overrides the " +
+            "evaluation context for that event instead of failing"
+    )
     class InvalidContextInMessage : Error("Field 'context' is not allowed in event's data")
 }

--- a/Confidence/src/main/java/com/spotify/confidence/EventSender.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/EventSender.kt
@@ -12,6 +12,16 @@ interface EventSender : Contextual {
     )
 
     /**
+     * Store a custom event to be tracked with an explicit evaluation context.
+     * @param eventContext evaluation context for this event only; does not mutate session context.
+     */
+    fun track(
+        eventName: String,
+        data: ConfidenceFieldsType,
+        eventContext: Map<String, ConfidenceValue>
+    )
+
+    /**
      * Track Android-specific events like activities or Track Context updates.
      * Please note that this method is collecting data in a coroutine scope and will be
      * executed on the dispatcher that was defined with the creation of the Confidence instance.

--- a/Confidence/src/main/java/com/spotify/confidence/EventSenderEngine.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/EventSenderEngine.kt
@@ -54,7 +54,12 @@ internal class EventSenderEngineImpl(
     // UNLIMITED buffering guarantees trySend succeeds for all events accepted
     // before stop(); see stopDrainsQueuedEventsBeforeUploading.
     private val writeReqChannel: Channel<EngineEvent> = Channel(Channel.UNLIMITED)
-    private val sendChannel: Channel<String> = Channel()
+    // Conflated + trySend so the writer never suspends while signaling flush. A
+    // rendezvous sendChannel.send() blocks the write loop during slow uploads
+    // (uploadMutex held), preventing writeReqChannel drain before stop() times out.
+    // Duplicate flush signals are harmless: uploadReadyBatches processes all
+    // ready files per invocation.
+    private val sendChannel: Channel<String> = Channel(Channel.CONFLATED)
     private val payloadMerger: PayloadMerger = PayloadMergerImpl(debugLogger)
 
     // Serializes read-upload-delete of ready files across the flush consumer,
@@ -93,7 +98,7 @@ internal class EventSenderEngineImpl(
                             message = "Flush policy $policy triggered to flush. Flushing."
                         )
                     }
-                    sendChannel.send(SEND_SIG)
+                    sendChannel.trySend(SEND_SIG)
                 }
             }
         }

--- a/Confidence/src/main/java/com/spotify/confidence/EventSenderEngine.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/EventSenderEngine.kt
@@ -41,8 +41,18 @@ internal class EventSenderEngineImpl(
     private val debugLogger: DebugLogger?,
     private val flushIntervalMillis: Long? = null
 ) : EventSenderEngine {
-    // Buffered so emit()/flush() can enqueue synchronously: every event accepted
-    // before stop() is drained to disk by the final flush.
+    // Main used Channel() (rendezvous, capacity 0) with suspending send() inside
+    // coroutineScope.launch. stop() only cancelled the scope, so in-flight emits
+    // could be lost.
+    //
+    // emit()/flush() now use trySend() on the caller thread so an event is either
+    // queued or rejected before stop() sets isStopped. stop() then closes this
+    // channel and joins writeJob to drain every queued event to disk.
+    //
+    // trySend on a rendezvous channel fails unless the consumer is already waiting,
+    // which would silently drop events whenever the writer is busy with disk I/O.
+    // UNLIMITED buffering guarantees trySend succeeds for all events accepted
+    // before stop(); see stopDrainsQueuedEventsBeforeUploading.
     private val writeReqChannel: Channel<EngineEvent> = Channel(Channel.UNLIMITED)
     private val sendChannel: Channel<String> = Channel()
     private val payloadMerger: PayloadMerger = PayloadMergerImpl(debugLogger)

--- a/Confidence/src/main/java/com/spotify/confidence/EventSenderEngine.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/EventSenderEngine.kt
@@ -195,9 +195,7 @@ internal class EventSenderEngineImpl(
                     sdkMetadata = sdkMetadata,
                     debugLogger = debugLogger,
                     flushIntervalMillis = flushIntervalMillis
-                ).also {
-                    Instance = it
-                }
+                )
             }
         }
     }

--- a/Confidence/src/main/java/com/spotify/confidence/EventSenderEngine.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/EventSenderEngine.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
@@ -41,25 +40,14 @@ internal class EventSenderEngineImpl(
     private val debugLogger: DebugLogger?,
     private val flushIntervalMillis: Long? = null
 ) : EventSenderEngine {
-    // Main used Channel() (rendezvous, capacity 0) with suspending send() inside
-    // coroutineScope.launch. stop() only cancelled the scope, so in-flight emits
-    // could be lost.
-    //
-    // emit()/flush() now use trySend() on the caller thread so an event is either
-    // queued or rejected before stop() sets isStopped. stop() then closes this
-    // channel and joins writeJob to drain every queued event to disk.
-    //
-    // trySend on a rendezvous channel fails unless the consumer is already waiting,
-    // which would silently drop events whenever the writer is busy with disk I/O.
-    // UNLIMITED buffering guarantees trySend succeeds for all events accepted
-    // before stop(); see stopDrainsQueuedEventsBeforeUploading.
+    // Buffering lets emit()/flush() enqueue without waiting for the disk writer.
+    // stop() closes the channel and the shutdown coroutine drains every accepted
+    // event before closing storage.
     private val writeReqChannel: Channel<EngineEvent> = Channel(Channel.UNLIMITED)
 
-    // Conflated + trySend so the writer never suspends while signaling flush. A
-    // rendezvous sendChannel.send() blocks the write loop during slow uploads
-    // (uploadMutex held), preventing writeReqChannel drain before stop() times out.
-    // Duplicate flush signals are harmless: uploadReadyBatches processes all
-    // ready files per invocation.
+    // Conflation preserves a flush signal while an upload is in progress without
+    // making the disk writer wait. Duplicate signals are unnecessary because each
+    // upload pass processes every ready batch.
     private val sendChannel: Channel<String> = Channel(Channel.CONFLATED)
     private val payloadMerger: PayloadMerger = PayloadMergerImpl(debugLogger)
 
@@ -157,22 +145,31 @@ internal class EventSenderEngineImpl(
         }
     }
 
+    @Synchronized
     override fun stop() {
+        if (isStopped) {
+            return
+        }
         isStopped = true
         flushIntervalJob?.cancel()
-        // Best effort: drain queued events to disk and attempt one final upload,
-        // bounded so stop() can never block the caller indefinitely. Batches that
-        // don't make it are sealed on disk and retried at next startup.
-        runBlocking(dispatcher) {
-            withTimeoutOrNull(STOP_TIMEOUT_MILLIS) {
-                writeReqChannel.close()
+        writeReqChannel.close()
+        // Shutdown stays on the engine dispatcher so callers, including Android's
+        // main thread, are not blocked by disk or network I/O.
+        coroutineScope.launch(exceptionHandler) {
+            try {
+                // Disk persistence is not timed out: every event accepted before
+                // stop() is sealed for delivery in this or a later session.
                 writeJob.join()
-                uploadReadyBatches(sealCurrentBatch = true)
+                eventStorage.rollover()
+                withTimeoutOrNull(STOP_UPLOAD_TIMEOUT_MILLIS) {
+                    uploadReadyBatches(sealCurrentBatch = false)
+                }
+            } finally {
+                coroutineScope.cancel()
+                eventStorage.stop()
+                debugLogger?.logMessage(message = "EventSenderEngine closed ")
             }
         }
-        coroutineScope.cancel()
-        eventStorage.stop()
-        debugLogger?.logMessage(message = "EventSenderEngine closed ")
     }
 
     private suspend fun uploadReadyBatches(sealCurrentBatch: Boolean) = uploadMutex.withLock {
@@ -218,7 +215,7 @@ internal class EventSenderEngineImpl(
 
     companion object {
         private const val SEND_SIG = "FLUSH"
-        private const val STOP_TIMEOUT_MILLIS = 2_000L
+        private const val STOP_UPLOAD_TIMEOUT_MILLIS = 2_000L
         private var Instance: EventSenderEngine? = null
         fun instance(
             context: Context,

--- a/Confidence/src/main/java/com/spotify/confidence/EventSenderEngine.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/EventSenderEngine.kt
@@ -54,6 +54,7 @@ internal class EventSenderEngineImpl(
     // UNLIMITED buffering guarantees trySend succeeds for all events accepted
     // before stop(); see stopDrainsQueuedEventsBeforeUploading.
     private val writeReqChannel: Channel<EngineEvent> = Channel(Channel.UNLIMITED)
+
     // Conflated + trySend so the writer never suspends while signaling flush. A
     // rendezvous sendChannel.send() blocks the write loop during slow uploads
     // (uploadMutex held), preventing writeReqChannel drain before stop() times out.

--- a/Confidence/src/main/java/com/spotify/confidence/EventSenderEngine.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/EventSenderEngine.kt
@@ -49,6 +49,7 @@ internal class EventSenderEngineImpl(
         }
     }
     private var flushIntervalJob: Job? = null
+
     @Volatile
     private var isStopped = false
 

--- a/Confidence/src/main/java/com/spotify/confidence/EventSenderEngine.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/EventSenderEngine.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.spotify.confidence.client.Clock
 import com.spotify.confidence.client.Sdk
 import com.spotify.confidence.client.SdkMetadata
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
@@ -16,6 +17,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.OkHttpClient
 import java.io.File
 
@@ -37,9 +41,15 @@ internal class EventSenderEngineImpl(
     private val debugLogger: DebugLogger?,
     private val flushIntervalMillis: Long? = null
 ) : EventSenderEngine {
-    private val writeReqChannel: Channel<EngineEvent> = Channel()
+    // Buffered so emit()/flush() can enqueue synchronously: every event accepted
+    // before stop() is drained to disk by the final flush.
+    private val writeReqChannel: Channel<EngineEvent> = Channel(Channel.UNLIMITED)
     private val sendChannel: Channel<String> = Channel()
-    private val payloadMerger: PayloadMerger = PayloadMergerImpl()
+    private val payloadMerger: PayloadMerger = PayloadMergerImpl(debugLogger)
+
+    // Serializes read-upload-delete of ready files across the flush consumer,
+    // the startup retry and stop(), so a batch is never uploaded twice.
+    private val uploadMutex = Mutex()
     private val coroutineScope by lazy {
         CoroutineScope(SupervisorJob() + dispatcher)
     }
@@ -49,13 +59,14 @@ internal class EventSenderEngineImpl(
         }
     }
     private var flushIntervalJob: Job? = null
+    private val writeJob: Job
 
     @Volatile
     private var isStopped = false
 
     init {
         flushPolicies.add(ManualFlushPolicy)
-        coroutineScope.launch(exceptionHandler) {
+        writeJob = coroutineScope.launch(exceptionHandler) {
             for (event in writeReqChannel) {
                 if (event.eventDefinition != manualFlushEvent.eventDefinition) {
                     eventStorage.writeEvent(event)
@@ -110,14 +121,13 @@ internal class EventSenderEngineImpl(
         if (isStopped) {
             return
         }
-        coroutineScope.launch {
-            val payload = payloadMerger(context, data)
-            val event = EngineEvent(
-                eventDefinition = eventName,
-                eventTime = clock.currentTime(),
-                payload = payload
-            )
-            writeReqChannel.send(event)
+        val payload = payloadMerger(context, data)
+        val event = EngineEvent(
+            eventDefinition = eventName,
+            eventTime = clock.currentTime(),
+            payload = payload
+        )
+        if (writeReqChannel.trySend(event).isSuccess) {
             debugLogger?.logEvent(action = "EmitEvent ", event = event)
         }
     }
@@ -126,8 +136,7 @@ internal class EventSenderEngineImpl(
         if (isStopped) {
             return
         }
-        coroutineScope.launch {
-            writeReqChannel.send(manualFlushEvent)
+        if (writeReqChannel.trySend(manualFlushEvent).isSuccess) {
             debugLogger?.logEvent(action = "Flush ", event = manualFlushEvent)
         }
     }
@@ -135,15 +144,22 @@ internal class EventSenderEngineImpl(
     override fun stop() {
         isStopped = true
         flushIntervalJob?.cancel()
+        // Best effort: drain queued events to disk and attempt one final upload,
+        // bounded so stop() can never block the caller indefinitely. Batches that
+        // don't make it are sealed on disk and retried at next startup.
         runBlocking(dispatcher) {
-            uploadReadyBatches(sealCurrentBatch = true)
+            withTimeoutOrNull(STOP_TIMEOUT_MILLIS) {
+                writeReqChannel.close()
+                writeJob.join()
+                uploadReadyBatches(sealCurrentBatch = true)
+            }
         }
         coroutineScope.cancel()
         eventStorage.stop()
         debugLogger?.logMessage(message = "EventSenderEngine closed ")
     }
 
-    private suspend fun uploadReadyBatches(sealCurrentBatch: Boolean) {
+    private suspend fun uploadReadyBatches(sealCurrentBatch: Boolean) = uploadMutex.withLock {
         if (sealCurrentBatch) {
             eventStorage.rollover()
         }
@@ -157,24 +173,36 @@ internal class EventSenderEngineImpl(
                         e.payload
                     )
                 }
+            if (events.isEmpty()) {
+                readyFile.delete()
+                continue
+            }
             val batch = EventBatchRequest(
                 clientSecret = clientSecret,
                 events = events,
                 sendTime = clock.currentTime(),
                 sdk = Sdk(sdkMetadata.sdkId, sdkMetadata.sdkVersion)
             )
-            runCatching {
+            try {
                 val shouldCleanup = uploader.upload(batch)
                 debugLogger?.logMessage(message = "Uploading events")
                 if (shouldCleanup) {
                     readyFile.delete()
                 }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                debugLogger?.logMessage(
+                    message = "Failed to upload events: $e",
+                    isWarning = true
+                )
             }
         }
     }
 
     companion object {
         private const val SEND_SIG = "FLUSH"
+        private const val STOP_TIMEOUT_MILLIS = 2_000L
         private var Instance: EventSenderEngine? = null
         fun instance(
             context: Context,

--- a/Confidence/src/main/java/com/spotify/confidence/EventSenderEngine.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/EventSenderEngine.kt
@@ -8,10 +8,14 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 import java.io.File
 
@@ -30,7 +34,8 @@ internal class EventSenderEngineImpl(
     private val clock: Clock = Clock.CalendarBacked.systemUTC(),
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val sdkMetadata: SdkMetadata,
-    private val debugLogger: DebugLogger?
+    private val debugLogger: DebugLogger?,
+    private val flushIntervalMillis: Long? = null
 ) : EventSenderEngine {
     private val writeReqChannel: Channel<EngineEvent> = Channel()
     private val sendChannel: Channel<String> = Channel()
@@ -43,13 +48,15 @@ internal class EventSenderEngineImpl(
             debugLogger?.logMessage(message = "EventSenderEngine error: $e", isWarning = true)
         }
     }
+    private var flushIntervalJob: Job? = null
+    @Volatile
+    private var isStopped = false
 
     init {
         flushPolicies.add(ManualFlushPolicy)
         coroutineScope.launch(exceptionHandler) {
             for (event in writeReqChannel) {
                 if (event.eventDefinition != manualFlushEvent.eventDefinition) {
-                    // skip storing manual flush event
                     eventStorage.writeEvent(event)
                     debugLogger?.logEvent(action = "DiskWrite ", event = event)
                 }
@@ -69,35 +76,23 @@ internal class EventSenderEngineImpl(
             }
         }
 
-        // upload might throw exceptions
         coroutineScope.launch(exceptionHandler) {
             for (flush in sendChannel) {
-                eventStorage.rollover()
-                val readyFiles = eventStorage.batchReadyFiles()
-                for (readyFile in readyFiles) {
-                    val events = eventStorage.eventsFor(readyFile)
-                        .map { e ->
-                            EngineEvent(
-                                "eventDefinitions/${e.eventDefinition}",
-                                e.eventTime,
-                                e.payload
-                            )
-                        }
-                    val batch = EventBatchRequest(
-                        clientSecret = clientSecret,
-                        events = events,
-                        sendTime = clock.currentTime(),
-                        sdk = Sdk(sdkMetadata.sdkId, sdkMetadata.sdkVersion)
-                    )
-                    runCatching {
-                        val shouldCleanup = uploader.upload(batch)
-                        debugLogger?.logMessage(message = "Uploading events")
-                        if (shouldCleanup) {
-                            readyFile.delete()
-                        }
-                    }
+                uploadReadyBatches(sealCurrentBatch = true)
+            }
+        }
+
+        if (flushIntervalMillis != null && flushIntervalMillis > 0) {
+            flushIntervalJob = coroutineScope.launch(exceptionHandler) {
+                while (isActive) {
+                    delay(flushIntervalMillis)
+                    flush()
                 }
             }
+        }
+
+        coroutineScope.launch(exceptionHandler) {
+            uploadReadyBatches(sealCurrentBatch = false)
         }
     }
 
@@ -111,6 +106,9 @@ internal class EventSenderEngineImpl(
         data: ConfidenceFieldsType,
         context: Map<String, ConfidenceValue>
     ) {
+        if (isStopped) {
+            return
+        }
         coroutineScope.launch {
             val payload = payloadMerger(context, data)
             val event = EngineEvent(
@@ -124,6 +122,9 @@ internal class EventSenderEngineImpl(
     }
 
     override fun flush() {
+        if (isStopped) {
+            return
+        }
         coroutineScope.launch {
             writeReqChannel.send(manualFlushEvent)
             debugLogger?.logEvent(action = "Flush ", event = manualFlushEvent)
@@ -131,9 +132,44 @@ internal class EventSenderEngineImpl(
     }
 
     override fun stop() {
+        isStopped = true
+        flushIntervalJob?.cancel()
+        runBlocking(dispatcher) {
+            uploadReadyBatches(sealCurrentBatch = true)
+        }
         coroutineScope.cancel()
         eventStorage.stop()
         debugLogger?.logMessage(message = "EventSenderEngine closed ")
+    }
+
+    private suspend fun uploadReadyBatches(sealCurrentBatch: Boolean) {
+        if (sealCurrentBatch) {
+            eventStorage.rollover()
+        }
+        val readyFiles = eventStorage.batchReadyFiles()
+        for (readyFile in readyFiles) {
+            val events = eventStorage.eventsFor(readyFile)
+                .map { e ->
+                    EngineEvent(
+                        "eventDefinitions/${e.eventDefinition}",
+                        e.eventTime,
+                        e.payload
+                    )
+                }
+            val batch = EventBatchRequest(
+                clientSecret = clientSecret,
+                events = events,
+                sendTime = clock.currentTime(),
+                sdk = Sdk(sdkMetadata.sdkId, sdkMetadata.sdkVersion)
+            )
+            runCatching {
+                val shouldCleanup = uploader.upload(batch)
+                debugLogger?.logMessage(message = "Uploading events")
+                if (shouldCleanup) {
+                    readyFile.delete()
+                }
+            }
+        }
     }
 
     companion object {
@@ -145,7 +181,8 @@ internal class EventSenderEngineImpl(
             sdkMetadata: SdkMetadata,
             flushPolicies: List<FlushPolicy> = listOf(),
             dispatcher: CoroutineDispatcher = Dispatchers.IO,
-            debugLogger: DebugLogger?
+            debugLogger: DebugLogger?,
+            flushIntervalMillis: Long? = null
         ): EventSenderEngine {
             return Instance ?: run {
                 EventSenderEngineImpl(
@@ -155,8 +192,11 @@ internal class EventSenderEngineImpl(
                     flushPolicies = flushPolicies.toMutableList(),
                     dispatcher = dispatcher,
                     sdkMetadata = sdkMetadata,
-                    debugLogger = debugLogger
-                )
+                    debugLogger = debugLogger,
+                    flushIntervalMillis = flushIntervalMillis
+                ).also {
+                    Instance = it
+                }
             }
         }
     }

--- a/Confidence/src/main/java/com/spotify/confidence/EventStorage.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/EventStorage.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
 import java.io.File
+import java.io.FileOutputStream
 import java.io.OutputStream
 
 internal interface EventStorage {
@@ -115,7 +116,8 @@ internal class EventStorageImpl(
         outputStream?.close()
         currentFile = latestWriteFile()
             ?: getFileWithName("events-${System.currentTimeMillis()}")
-        outputStream = currentFile.outputStream()
+        // Append so events persisted by a previous session are not truncated
+        outputStream = FileOutputStream(currentFile, true)
     }
     private fun getFileWithName(name: String): File {
         val directory = context.getDir(DIRECTORY, Context.MODE_PRIVATE)

--- a/Confidence/src/main/java/com/spotify/confidence/PayloadMerger.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/PayloadMerger.kt
@@ -4,9 +4,11 @@ private typealias ConfidenceStruct = Map<String, ConfidenceValue>
 internal interface PayloadMerger : (ConfidenceStruct, ConfidenceStruct) -> ConfidenceStruct
 internal class PayloadMergerImpl : PayloadMerger {
     override fun invoke(context: ConfidenceStruct, message: ConfidenceStruct): ConfidenceStruct {
-        if (message.containsKey("context")) {
-            throw ConfidenceError.InvalidContextInMessage()
+        return if (message.containsKey("context")) {
+            // An explicit "context" entry in event data overrides the evaluation context for this event.
+            message
+        } else {
+            message + mapOf("context" to ConfidenceValue.Struct(context))
         }
-        return message + (mapOf("context" to ConfidenceValue.Struct(context)))
     }
 }

--- a/Confidence/src/main/java/com/spotify/confidence/PayloadMerger.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/PayloadMerger.kt
@@ -2,10 +2,16 @@ package com.spotify.confidence
 
 private typealias ConfidenceStruct = Map<String, ConfidenceValue>
 internal interface PayloadMerger : (ConfidenceStruct, ConfidenceStruct) -> ConfidenceStruct
-internal class PayloadMergerImpl : PayloadMerger {
+internal class PayloadMergerImpl(
+    private val debugLogger: DebugLogger? = null
+) : PayloadMerger {
     override fun invoke(context: ConfidenceStruct, message: ConfidenceStruct): ConfidenceStruct {
         return if (message.containsKey("context")) {
             // An explicit "context" entry in event data overrides the evaluation context for this event.
+            debugLogger?.logMessage(
+                message = "Event data contains a 'context' field: it replaces the evaluation context for this event",
+                isWarning = true
+            )
             message
         } else {
             message + mapOf("context" to ConfidenceValue.Struct(context))

--- a/Confidence/src/main/java/com/spotify/confidence/PayloadMerger.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/PayloadMerger.kt
@@ -12,7 +12,7 @@ internal class PayloadMergerImpl(
                 message = "Event data contains a 'context' field: it replaces the evaluation context for this event",
                 isWarning = true
             )
-            message
+            message.toMap()
         } else {
             message + mapOf("context" to ConfidenceValue.Struct(context))
         }

--- a/Confidence/src/test/java/com/spotify/confidence/EventSenderEngineReliabilityTest.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/EventSenderEngineReliabilityTest.kt
@@ -78,6 +78,7 @@ class EventSenderEngineReliabilityTest {
         repeat(50) { engine.emit("event-$it", mapOf(), mapOf()) }
         engine.stop()
 
+        awaitCondition { uploader.uploadedEventNames.size == 50 }
         assertEquals(50, uploader.uploadedEventNames.size)
     }
 
@@ -106,13 +107,40 @@ class EventSenderEngineReliabilityTest {
 
         repeat(12) { engine.emit("event-$it", mapOf(), mapOf()) }
         Thread.sleep(100)
+        val stopStartedAt = System.nanoTime()
         engine.stop()
 
+        val stopDurationMillis = (System.nanoTime() - stopStartedAt) / 1_000_000
+        assertTrue("stop() blocked for ${stopDurationMillis}ms", stopDurationMillis < 500)
+        awaitCondition { storage.storedEventCount() == 12 }
         assertEquals(
-            "All 12 events should be written to storage before stop() returns",
+            "All 12 events should be written to storage after stop() starts shutdown",
             12,
             storage.storedEventCount()
         )
+    }
+
+    @Test
+    fun stopDoesNotTimeOutDiskDrain() {
+        storage = RecordingEventStorage(writeDelayMillis = 2_100)
+        val engine = EventSenderEngineImpl(
+            eventStorage = storage,
+            clientSecret = "secret",
+            uploader = RetainingEventUploader(),
+            flushPolicies = mutableListOf(),
+            dispatcher = Dispatchers.IO,
+            sdkMetadata = SdkMetadata("id", "1.0"),
+            debugLogger = null
+        )
+
+        engine.emit("slow-write", mapOf(), mapOf())
+        val stopStartedAt = System.nanoTime()
+        engine.stop()
+
+        val stopDurationMillis = (System.nanoTime() - stopStartedAt) / 1_000_000
+        assertTrue("stop() blocked for ${stopDurationMillis}ms", stopDurationMillis < 500)
+        awaitCondition { storage.isStopped }
+        assertEquals(1, storage.storedEventCount())
     }
 
     @Test
@@ -166,18 +194,29 @@ class EventSenderEngineReliabilityTest {
 
     // Mimics EventStorageImpl: rollover always seals the current batch (even when
     // empty) and uploaded batches disappear when their file is deleted.
-    private class RecordingEventStorage : EventStorage {
+    private class RecordingEventStorage(
+        private val writeDelayMillis: Long = 0
+    ) : EventStorage {
         val currentEvents = mutableListOf<EngineEvent>()
         val readyEvents = mutableMapOf<String, List<EngineEvent>>()
         private var batchCounter = 0
+
+        @Volatile
+        var isStopped = false
+            private set
 
         override suspend fun rollover(): Unit = synchronized(this) {
             readyEvents["batch-${batchCounter++}"] = currentEvents.toList()
             currentEvents.clear()
         }
 
-        override suspend fun writeEvent(event: EngineEvent): Unit = synchronized(this) {
-            currentEvents.add(event)
+        override suspend fun writeEvent(event: EngineEvent) {
+            if (writeDelayMillis > 0) {
+                delay(writeDelayMillis)
+            }
+            synchronized(this) {
+                currentEvents.add(event)
+            }
         }
 
         override suspend fun batchReadyFiles(): List<java.io.File> = synchronized(this) {
@@ -197,6 +236,7 @@ class EventSenderEngineReliabilityTest {
         override fun onLowMemoryChannel() = kotlinx.coroutines.channels.Channel<List<java.io.File>>()
 
         override fun stop() {
+            isStopped = true
         }
 
         fun storedEventCount(): Int = synchronized(this) {
@@ -211,5 +251,20 @@ class EventSenderEngineReliabilityTest {
             delay(uploadDelayMillis)
             return true
         }
+    }
+
+    private class RetainingEventUploader : EventSenderUploader {
+        override suspend fun upload(events: EventBatchRequest): Boolean = false
+    }
+
+    private fun awaitCondition(
+        timeoutMillis: Long = 5_000,
+        condition: () -> Boolean
+    ) {
+        val deadline = System.nanoTime() + timeoutMillis * 1_000_000
+        while (!condition() && System.nanoTime() < deadline) {
+            Thread.sleep(10)
+        }
+        assertTrue("Condition was not met within ${timeoutMillis}ms", condition())
     }
 }

--- a/Confidence/src/test/java/com/spotify/confidence/EventSenderEngineReliabilityTest.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/EventSenderEngineReliabilityTest.kt
@@ -1,0 +1,129 @@
+package com.spotify.confidence
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.Date
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EventSenderEngineReliabilityTest {
+    private lateinit var testDispatcher: UnconfinedTestDispatcher
+    private lateinit var uploader: RecordingEventUploader
+    private lateinit var storage: RecordingEventStorage
+
+    @Before
+    fun setUp() {
+        testDispatcher = UnconfinedTestDispatcher()
+        uploader = RecordingEventUploader()
+        storage = RecordingEventStorage()
+    }
+
+    @Test
+    fun startupUploadsPendingReadyBatchesWithoutSealingCurrentBatch() = runTest(testDispatcher) {
+        storage.readyEvents["pending.batch"] = listOf(
+            EngineEvent("pending", Date(), mapOf())
+        )
+        storage.currentEvents.add(
+            EngineEvent("current", Date(), mapOf())
+        )
+
+        EventSenderEngineImpl(
+            eventStorage = storage,
+            clientSecret = "secret",
+            uploader = uploader,
+            flushPolicies = mutableListOf(),
+            dispatcher = testDispatcher,
+            sdkMetadata = com.spotify.confidence.client.SdkMetadata("id", "1.0"),
+            debugLogger = null
+        )
+
+        advanceUntilIdle()
+
+        assertEquals(listOf("pending"), uploader.uploadedEventNames)
+        assertEquals(listOf("current"), storage.currentEvents.map { it.eventDefinition })
+    }
+
+    @Test
+    fun stopUploadsCurrentBatch() = runTest(testDispatcher) {
+        val engine = EventSenderEngineImpl(
+            eventStorage = storage,
+            clientSecret = "secret",
+            uploader = uploader,
+            flushPolicies = mutableListOf(),
+            dispatcher = testDispatcher,
+            sdkMetadata = com.spotify.confidence.client.SdkMetadata("id", "1.0"),
+            debugLogger = null
+        )
+
+        engine.emit("session-end", mapOf(), mapOf())
+        advanceUntilIdle()
+        engine.stop()
+
+        assertTrue(uploader.uploadedEventNames.contains("session-end"))
+    }
+
+    @Test
+    fun periodicFlushIntervalUploadsEvents() = runTest(testDispatcher) {
+        val engine = EventSenderEngineImpl(
+            eventStorage = storage,
+            clientSecret = "secret",
+            uploader = uploader,
+            flushPolicies = mutableListOf(),
+            dispatcher = testDispatcher,
+            sdkMetadata = com.spotify.confidence.client.SdkMetadata("id", "1.0"),
+            debugLogger = null,
+            flushIntervalMillis = 100
+        )
+
+        engine.emit("interval-event", mapOf(), mapOf())
+        advanceUntilIdle()
+        testScheduler.advanceTimeBy(150)
+        advanceUntilIdle()
+        engine.stop()
+
+        assertTrue(uploader.uploadedEventNames.contains("interval-event"))
+    }
+
+    private class RecordingEventUploader : EventSenderUploader {
+        val uploadedEventNames = mutableListOf<String>()
+
+        override suspend fun upload(events: EventBatchRequest): Boolean {
+            uploadedEventNames.addAll(events.events.map { it.eventDefinition.removePrefix("eventDefinitions/") })
+            return true
+        }
+    }
+
+    private class RecordingEventStorage : EventStorage {
+        val currentEvents = mutableListOf<EngineEvent>()
+        val readyEvents = mutableMapOf<String, List<EngineEvent>>()
+
+        override suspend fun rollover() {
+            if (currentEvents.isNotEmpty()) {
+                readyEvents["batch-${readyEvents.size}"] = currentEvents.toList()
+                currentEvents.clear()
+            }
+        }
+
+        override suspend fun writeEvent(event: EngineEvent) {
+            currentEvents.add(event)
+        }
+
+        override suspend fun batchReadyFiles(): List<java.io.File> {
+            return readyEvents.keys.map { java.io.File(it) }
+        }
+
+        override suspend fun eventsFor(file: java.io.File): List<EngineEvent> {
+            return readyEvents[file.name].orEmpty()
+        }
+
+        override fun onLowMemoryChannel() = kotlinx.coroutines.channels.Channel<List<java.io.File>>()
+
+        override fun stop() {
+        }
+    }
+}

--- a/Confidence/src/test/java/com/spotify/confidence/EventSenderEngineReliabilityTest.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/EventSenderEngineReliabilityTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.delay
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -78,6 +79,40 @@ class EventSenderEngineReliabilityTest {
         engine.stop()
 
         assertEquals(50, uploader.uploadedEventNames.size)
+    }
+
+    @Test
+    fun stopDrainsAllEventsWhenFlushPolicyBlocksWriter() {
+        val slowUploader = SlowEventUploader(uploadDelayMillis = 3_000)
+        val batchFlush = object : FlushPolicy {
+            private var count = 0
+            override fun reset() {
+                count = 0
+            }
+            override fun hit(event: EngineEvent) {
+                count++
+            }
+            override fun shouldFlush(): Boolean = count > 4
+        }
+        val engine = EventSenderEngineImpl(
+            eventStorage = storage,
+            clientSecret = "secret",
+            uploader = slowUploader,
+            flushPolicies = mutableListOf(batchFlush),
+            dispatcher = Dispatchers.IO,
+            sdkMetadata = SdkMetadata("id", "1.0"),
+            debugLogger = null
+        )
+
+        repeat(12) { engine.emit("event-$it", mapOf(), mapOf()) }
+        Thread.sleep(100)
+        engine.stop()
+
+        assertEquals(
+            "All 12 events should be written to storage before stop() returns",
+            12,
+            storage.storedEventCount()
+        )
     }
 
     @Test
@@ -162,6 +197,19 @@ class EventSenderEngineReliabilityTest {
         override fun onLowMemoryChannel() = kotlinx.coroutines.channels.Channel<List<java.io.File>>()
 
         override fun stop() {
+        }
+
+        fun storedEventCount(): Int = synchronized(this) {
+            currentEvents.size + readyEvents.values.sumOf { it.size }
+        }
+    }
+
+    private class SlowEventUploader(
+        private val uploadDelayMillis: Long
+    ) : EventSenderUploader {
+        override suspend fun upload(events: EventBatchRequest): Boolean {
+            delay(uploadDelayMillis)
+            return true
         }
     }
 }

--- a/Confidence/src/test/java/com/spotify/confidence/EventSenderEngineReliabilityTest.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/EventSenderEngineReliabilityTest.kt
@@ -4,11 +4,11 @@ import com.spotify.confidence.client.SdkMetadata
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.delay
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before

--- a/Confidence/src/test/java/com/spotify/confidence/EventSenderEngineReliabilityTest.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/EventSenderEngineReliabilityTest.kt
@@ -1,6 +1,10 @@
 package com.spotify.confidence
 
+import com.spotify.confidence.client.SdkMetadata
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -12,7 +16,7 @@ import java.util.Date
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class EventSenderEngineReliabilityTest {
-    private lateinit var testDispatcher: UnconfinedTestDispatcher
+    private lateinit var testDispatcher: TestDispatcher
     private lateinit var uploader: RecordingEventUploader
     private lateinit var storage: RecordingEventStorage
 
@@ -23,6 +27,20 @@ class EventSenderEngineReliabilityTest {
         storage = RecordingEventStorage()
     }
 
+    private fun engine(
+        dispatcher: CoroutineDispatcher = testDispatcher,
+        flushIntervalMillis: Long? = null
+    ) = EventSenderEngineImpl(
+        eventStorage = storage,
+        clientSecret = "secret",
+        uploader = uploader,
+        flushPolicies = mutableListOf(),
+        dispatcher = dispatcher,
+        sdkMetadata = SdkMetadata("id", "1.0"),
+        debugLogger = null,
+        flushIntervalMillis = flushIntervalMillis
+    )
+
     @Test
     fun startupUploadsPendingReadyBatchesWithoutSealingCurrentBatch() = runTest(testDispatcher) {
         storage.readyEvents["pending.batch"] = listOf(
@@ -32,93 +50,113 @@ class EventSenderEngineReliabilityTest {
             EngineEvent("current", Date(), mapOf())
         )
 
-        EventSenderEngineImpl(
-            eventStorage = storage,
-            clientSecret = "secret",
-            uploader = uploader,
-            flushPolicies = mutableListOf(),
-            dispatcher = testDispatcher,
-            sdkMetadata = com.spotify.confidence.client.SdkMetadata("id", "1.0"),
-            debugLogger = null
-        )
+        engine()
 
         advanceUntilIdle()
 
         assertEquals(listOf("pending"), uploader.uploadedEventNames)
         assertEquals(listOf("current"), storage.currentEvents.map { it.eventDefinition })
+        assertTrue(storage.readyEvents.isEmpty())
     }
 
     @Test
     fun stopUploadsCurrentBatch() = runTest(testDispatcher) {
-        val engine = EventSenderEngineImpl(
-            eventStorage = storage,
-            clientSecret = "secret",
-            uploader = uploader,
-            flushPolicies = mutableListOf(),
-            dispatcher = testDispatcher,
-            sdkMetadata = com.spotify.confidence.client.SdkMetadata("id", "1.0"),
-            debugLogger = null
-        )
+        val engine = engine()
 
         engine.emit("session-end", mapOf(), mapOf())
         advanceUntilIdle()
         engine.stop()
 
-        assertTrue(uploader.uploadedEventNames.contains("session-end"))
+        assertEquals(listOf("session-end"), uploader.uploadedEventNames)
     }
 
     @Test
-    fun periodicFlushIntervalUploadsEvents() = runTest(testDispatcher) {
-        val engine = EventSenderEngineImpl(
-            eventStorage = storage,
-            clientSecret = "secret",
-            uploader = uploader,
-            flushPolicies = mutableListOf(),
-            dispatcher = testDispatcher,
-            sdkMetadata = com.spotify.confidence.client.SdkMetadata("id", "1.0"),
-            debugLogger = null,
-            flushIntervalMillis = 100
-        )
+    fun stopDrainsQueuedEventsBeforeUploading() {
+        val engine = engine(dispatcher = Dispatchers.IO)
 
-        engine.emit("interval-event", mapOf(), mapOf())
-        advanceUntilIdle()
-        testScheduler.advanceTimeBy(150)
-        advanceUntilIdle()
+        repeat(50) { engine.emit("event-$it", mapOf(), mapOf()) }
         engine.stop()
 
-        assertTrue(uploader.uploadedEventNames.contains("interval-event"))
+        assertEquals(50, uploader.uploadedEventNames.size)
+    }
+
+    @Test
+    fun emitAfterStopIsIgnored() = runTest(testDispatcher) {
+        val engine = engine()
+
+        engine.stop()
+        engine.emit("late-event", mapOf(), mapOf())
+        advanceUntilIdle()
+
+        assertTrue(uploader.uploadedEventNames.isEmpty())
+    }
+
+    @Test
+    fun periodicFlushIntervalUploadsEventsExactlyOnce() = runTest(testDispatcher) {
+        val engine = engine(flushIntervalMillis = 100)
+
+        engine.emit("interval-event", mapOf(), mapOf())
+        testScheduler.runCurrent()
+        // advanceUntilIdle would spin forever on the self-rescheduling interval job
+        testScheduler.advanceTimeBy(150)
+        testScheduler.runCurrent()
+        engine.stop()
+
+        assertEquals(listOf("interval-event"), uploader.uploadedEventNames)
+    }
+
+    @Test
+    fun periodicFlushWithoutEventsDoesNotUpload() = runTest(testDispatcher) {
+        val engine = engine(flushIntervalMillis = 100)
+
+        testScheduler.advanceTimeBy(350)
+        testScheduler.runCurrent()
+        engine.stop()
+
+        assertTrue(uploader.uploadedEventNames.isEmpty())
     }
 
     private class RecordingEventUploader : EventSenderUploader {
         val uploadedEventNames = mutableListOf<String>()
 
         override suspend fun upload(events: EventBatchRequest): Boolean {
-            uploadedEventNames.addAll(events.events.map { it.eventDefinition.removePrefix("eventDefinitions/") })
+            synchronized(uploadedEventNames) {
+                uploadedEventNames.addAll(
+                    events.events.map { it.eventDefinition.removePrefix("eventDefinitions/") }
+                )
+            }
             return true
         }
     }
 
+    // Mimics EventStorageImpl: rollover always seals the current batch (even when
+    // empty) and uploaded batches disappear when their file is deleted.
     private class RecordingEventStorage : EventStorage {
         val currentEvents = mutableListOf<EngineEvent>()
         val readyEvents = mutableMapOf<String, List<EngineEvent>>()
+        private var batchCounter = 0
 
-        override suspend fun rollover() {
-            if (currentEvents.isNotEmpty()) {
-                readyEvents["batch-${readyEvents.size}"] = currentEvents.toList()
-                currentEvents.clear()
-            }
+        override suspend fun rollover(): Unit = synchronized(this) {
+            readyEvents["batch-${batchCounter++}"] = currentEvents.toList()
+            currentEvents.clear()
         }
 
-        override suspend fun writeEvent(event: EngineEvent) {
+        override suspend fun writeEvent(event: EngineEvent): Unit = synchronized(this) {
             currentEvents.add(event)
         }
 
-        override suspend fun batchReadyFiles(): List<java.io.File> {
-            return readyEvents.keys.map { java.io.File(it) }
+        override suspend fun batchReadyFiles(): List<java.io.File> = synchronized(this) {
+            readyEvents.keys.map { name ->
+                object : java.io.File(name) {
+                    override fun delete(): Boolean = synchronized(this@RecordingEventStorage) {
+                        readyEvents.remove(name) != null
+                    }
+                }
+            }
         }
 
-        override suspend fun eventsFor(file: java.io.File): List<EngineEvent> {
-            return readyEvents[file.name].orEmpty()
+        override suspend fun eventsFor(file: java.io.File): List<EngineEvent> = synchronized(this) {
+            readyEvents[file.name].orEmpty()
         }
 
         override fun onLowMemoryChannel() = kotlinx.coroutines.channels.Channel<List<java.io.File>>()

--- a/Confidence/src/test/java/com/spotify/confidence/EventSenderIntegrationTest.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/EventSenderIntegrationTest.kt
@@ -2,7 +2,6 @@ package com.spotify.confidence
 
 import android.content.Context
 import android.content.SharedPreferences
-import com.spotify.confidence.ConfidenceError.InvalidContextInMessage
 import com.spotify.confidence.client.SdkMetadata
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -43,15 +42,29 @@ class EventSenderIntegrationTest {
         }
     }
 
-    @Test(expected = InvalidContextInMessage::class)
-    fun context_in_message_throws() = runTest {
+    @Test
+    fun context_in_message_overrides_evaluation_context() = runTest {
         val testDispatcher = UnconfinedTestDispatcher(testScheduler)
         val confidence = ConfidenceFactory.create(
             mockContext,
             clientSecret,
             dispatcher = testDispatcher
         )
-        confidence.track("test", mapOf("context" to ConfidenceValue.Integer(1)))
+        confidence.track(
+            eventName = "test",
+            data = mapOf("context" to ConfidenceValue.String("override")),
+            eventContext = mapOf("a" to ConfidenceValue.Integer(1))
+        )
+        advanceUntilIdle()
+        val eventStorage = EventStorageImpl(mockContext)
+        val files = directory.walkFiles().toList()
+        Assert.assertEquals(1, files.size)
+        val events = eventStorage.eventsFor(files.first())
+        Assert.assertEquals(1, events.size)
+        Assert.assertEquals(
+            ConfidenceValue.String("override"),
+            events.first().payload["context"]
+        )
     }
 
     @Test

--- a/Confidence/src/test/java/com/spotify/confidence/EventSenderIntegrationTest.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/EventSenderIntegrationTest.kt
@@ -37,6 +37,9 @@ class EventSenderIntegrationTest {
         whenever(mockSharedPrefsEdit.putString(any(), any())).thenReturn(mockSharedPrefsEdit)
         doNothing().whenever(mockSharedPrefsEdit).apply()
         eventSender = null
+        // minBatchSizeFlushPolicy is a shared singleton: reset its count so
+        // events emitted by earlier tests can't trigger a flush in this one
+        minBatchSizeFlushPolicy.reset()
         for (file in directory.walkFiles()) {
             file.delete()
         }
@@ -57,9 +60,7 @@ class EventSenderIntegrationTest {
         )
         advanceUntilIdle()
         val eventStorage = EventStorageImpl(mockContext)
-        val files = directory.walkFiles().toList()
-        Assert.assertEquals(1, files.size)
-        val events = eventStorage.eventsFor(files.first())
+        val events = directory.walkFiles().toList().flatMap { eventStorage.eventsFor(it) }
         Assert.assertEquals(1, events.size)
         Assert.assertEquals(
             ConfidenceValue.String("override"),

--- a/Confidence/src/test/java/com/spotify/confidence/PayloadMergerTest.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/PayloadMergerTest.kt
@@ -22,4 +22,21 @@ class PayloadMergerTest {
             )
         )
     }
+
+    @Test
+    fun `context in data overrides evaluation context`() {
+        val payloadMerger = PayloadMergerImpl()
+        val context = mapOf("a" to ConfidenceValue.Integer(1), "b" to ConfidenceValue.Integer(2))
+        val message = mapOf(
+            "b" to ConfidenceValue.Integer(3),
+            "context" to ConfidenceValue.String("override")
+        )
+        val result = payloadMerger(context, message)
+        assert(
+            result == mapOf(
+                "b" to ConfidenceValue.Integer(3),
+                "context" to ConfidenceValue.String("override")
+            )
+        )
+    }
 }

--- a/Confidence/src/test/java/com/spotify/confidence/PayloadMergerTest.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/PayloadMergerTest.kt
@@ -27,11 +27,14 @@ class PayloadMergerTest {
     fun `context in data overrides evaluation context`() {
         val payloadMerger = PayloadMergerImpl()
         val context = mapOf("a" to ConfidenceValue.Integer(1), "b" to ConfidenceValue.Integer(2))
-        val message = mapOf(
+        val message = mutableMapOf(
             "b" to ConfidenceValue.Integer(3),
             "context" to ConfidenceValue.String("override")
         )
         val result = payloadMerger(context, message)
+        message["b"] = ConfidenceValue.Integer(4)
+        message["new"] = ConfidenceValue.String("late mutation")
+
         assert(
             result == mapOf(
                 "b" to ConfidenceValue.Integer(3),

--- a/Provider/src/main/java/com/spotify/confidence/openfeature/ConfidenceFeatureProvider.kt
+++ b/Provider/src/main/java/com/spotify/confidence/openfeature/ConfidenceFeatureProvider.kt
@@ -113,7 +113,15 @@ class ConfidenceFeatureProvider private constructor(
     }
 
     override fun track(trackingEventName: String, context: EvaluationContext?, details: TrackingEventDetails?) {
-        confidence.track(trackingEventName, details?.toConfidenceValue() ?: emptyMap())
+        val eventContext = mergeEventContext(
+            sessionContext = confidence.getContext(),
+            openFeatureContext = context.toTrackContextMap()
+        )
+        confidence.track(
+            eventName = trackingEventName,
+            data = details.toTrackingData(),
+            eventContext = eventContext
+        )
     }
 
     private fun <T> generateEvaluation(
@@ -155,16 +163,6 @@ class ConfidenceFeatureProvider private constructor(
             )
         }
     }
-}
-
-private fun TrackingEventDetails.toConfidenceValue(): Map<String, ConfidenceValue> = mapOf(
-    "value" to (this.value?.toConfidenceValue() ?: ConfidenceValue.Null)
-) + this.structure.asMap().mapValues { it.value.toConfidenceValue() }
-
-private fun Number.toConfidenceValue(): ConfidenceValue = when (this) {
-    is Int -> ConfidenceValue.Integer(this)
-    is Double -> ConfidenceValue.Double(this)
-    else -> ConfidenceValue.Null
 }
 
 internal fun Value.toConfidenceValue(): ConfidenceValue = when (this) {

--- a/Provider/src/main/java/com/spotify/confidence/openfeature/ConfidenceFeatureProvider.kt
+++ b/Provider/src/main/java/com/spotify/confidence/openfeature/ConfidenceFeatureProvider.kt
@@ -52,6 +52,11 @@ class ConfidenceFeatureProvider private constructor(
         }
     }
 
+    /**
+     * Triggers a best-effort flush of tracked events: delivery is asynchronous
+     * and not guaranteed before process death. Undelivered batches are retried
+     * on the next SDK startup.
+     */
     override fun shutdown() {
         confidence.flush()
     }

--- a/Provider/src/main/java/com/spotify/confidence/openfeature/ConfidenceFeatureProvider.kt
+++ b/Provider/src/main/java/com/spotify/confidence/openfeature/ConfidenceFeatureProvider.kt
@@ -53,6 +53,7 @@ class ConfidenceFeatureProvider private constructor(
     }
 
     override fun shutdown() {
+        confidence.flush()
     }
 
     override suspend fun onContextSet(

--- a/Provider/src/main/java/com/spotify/confidence/openfeature/OpenFeatureTrackMapper.kt
+++ b/Provider/src/main/java/com/spotify/confidence/openfeature/OpenFeatureTrackMapper.kt
@@ -1,0 +1,43 @@
+package com.spotify.confidence.openfeature
+
+import com.spotify.confidence.ConfidenceValue
+import dev.openfeature.kotlin.sdk.EvaluationContext
+import dev.openfeature.kotlin.sdk.TrackingEventDetails
+
+internal fun mergeEventContext(
+    sessionContext: Map<String, ConfidenceValue>,
+    openFeatureContext: Map<String, ConfidenceValue>
+): Map<String, ConfidenceValue> {
+    if (openFeatureContext.isEmpty()) {
+        return sessionContext
+    }
+    return sessionContext + openFeatureContext
+}
+
+internal fun EvaluationContext?.toTrackContextMap(): Map<String, ConfidenceValue> {
+    if (this == null) {
+        return emptyMap()
+    }
+    val map = mutableMapOf<String, ConfidenceValue>()
+    val targetingKey = getTargetingKey()
+    if (targetingKey.isNotEmpty() && !asMap().containsKey("targeting_key")) {
+        map["targeting_key"] = ConfidenceValue.String(targetingKey)
+    }
+    map.putAll(asMap().mapValues { it.value.toConfidenceValue() })
+    return map
+}
+
+internal fun TrackingEventDetails?.toTrackingData(): Map<String, ConfidenceValue> {
+    if (this == null) {
+        return emptyMap()
+    }
+    return mapOf(
+        "value" to (value?.toConfidenceValue() ?: ConfidenceValue.Null)
+    ) + structure.asMap().mapValues { it.value.toConfidenceValue() }
+}
+
+private fun Number.toConfidenceValue(): ConfidenceValue = when (this) {
+    is Int -> ConfidenceValue.Integer(this)
+    is Double -> ConfidenceValue.Double(this)
+    else -> ConfidenceValue.Null
+}

--- a/Provider/src/main/java/com/spotify/confidence/openfeature/OpenFeatureTrackMapper.kt
+++ b/Provider/src/main/java/com/spotify/confidence/openfeature/OpenFeatureTrackMapper.kt
@@ -20,9 +20,10 @@ internal fun EvaluationContext?.toTrackContextMap(): Map<String, ConfidenceValue
     }
     val map = mutableMapOf<String, ConfidenceValue>()
     val targetingKey = getTargetingKey()
-    if (targetingKey.isNotEmpty() && !asMap().containsKey("targeting_key")) {
+    if (targetingKey.isNotEmpty()) {
         map["targeting_key"] = ConfidenceValue.String(targetingKey)
     }
+    // Explicit attributes win over the injected targeting key
     map.putAll(asMap().mapValues { it.value.toConfidenceValue() })
     return map
 }
@@ -38,6 +39,12 @@ internal fun TrackingEventDetails?.toTrackingData(): Map<String, ConfidenceValue
 
 private fun Number.toConfidenceValue(): ConfidenceValue = when (this) {
     is Int -> ConfidenceValue.Integer(this)
+    is Long -> if (this in Int.MIN_VALUE..Int.MAX_VALUE) {
+        ConfidenceValue.Integer(toInt())
+    } else {
+        ConfidenceValue.Double(toDouble())
+    }
     is Double -> ConfidenceValue.Double(this)
+    is Float -> ConfidenceValue.Double(toDouble())
     else -> ConfidenceValue.Null
 }

--- a/Provider/src/test/java/com/spotify/confidence/openfeature/ConfidenceFeatureProviderTrackTest.kt
+++ b/Provider/src/test/java/com/spotify/confidence/openfeature/ConfidenceFeatureProviderTrackTest.kt
@@ -1,0 +1,118 @@
+package com.spotify.confidence.openfeature
+
+import com.spotify.confidence.Confidence
+import com.spotify.confidence.ConfidenceValue
+import dev.openfeature.kotlin.sdk.ImmutableContext
+import dev.openfeature.kotlin.sdk.ImmutableStructure
+import dev.openfeature.kotlin.sdk.TrackingEventDetails
+import dev.openfeature.kotlin.sdk.Value
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ConfidenceFeatureProviderTrackTest {
+    @Test
+    fun trackForwardsMergedContextAndMappedData() {
+        val confidence = mockk<Confidence>(relaxed = true)
+        every { confidence.getContext() } returns mapOf("plan" to ConfidenceValue.String("free"))
+
+        val dataSlot = slot<Map<String, ConfidenceValue>>()
+        val contextSlot = slot<Map<String, ConfidenceValue>>()
+        every {
+            confidence.track(
+                eventName = "Checkout",
+                data = capture(dataSlot),
+                eventContext = capture(contextSlot)
+            )
+        } returns Unit
+
+        val provider = ConfidenceFeatureProvider.create(confidence)
+        val details = TrackingEventDetails(
+            499.99,
+            ImmutableStructure(
+                "numberOfItems" to Value.Integer(4),
+                "timeInCheckout" to Value.String("PT3M20S")
+            )
+        )
+        val context = ImmutableContext(
+            targetingKey = "user-1",
+            attributes = mapOf(
+                "plan" to Value.String("premium"),
+                "country" to Value.String("SE")
+            )
+        )
+
+        provider.track("Checkout", context, details)
+
+        verify {
+            confidence.track(
+                eventName = "Checkout",
+                data = any(),
+                eventContext = any()
+            )
+        }
+        assertEquals(ConfidenceValue.Double(499.99), dataSlot.captured["value"])
+        assertEquals(ConfidenceValue.Integer(4), dataSlot.captured["numberOfItems"])
+        assertEquals(ConfidenceValue.String("premium"), contextSlot.captured["plan"])
+        assertEquals(ConfidenceValue.String("SE"), contextSlot.captured["country"])
+        assertEquals(ConfidenceValue.String("user-1"), contextSlot.captured["targeting_key"])
+    }
+
+    @Test
+    fun trackWithoutDetailsSendsEmptyData() {
+        val confidence = mockk<Confidence>(relaxed = true)
+        every { confidence.getContext() } returns emptyMap()
+
+        val dataSlot = slot<Map<String, ConfidenceValue>>()
+        every {
+            confidence.track(
+                eventName = "PageView",
+                data = capture(dataSlot),
+                eventContext = any()
+            )
+        } returns Unit
+
+        val provider = ConfidenceFeatureProvider.create(confidence)
+        provider.track("PageView", null, null)
+
+        assertTrue(dataSlot.captured.isEmpty())
+    }
+
+    @Test
+    fun trackContextAttributeOverridesMergedEvaluationContext() {
+        val confidence = mockk<Confidence>(relaxed = true)
+        every { confidence.getContext() } returns mapOf("plan" to ConfidenceValue.String("free"))
+
+        val dataSlot = slot<Map<String, ConfidenceValue>>()
+        every {
+            confidence.track(
+                eventName = "Checkout",
+                data = capture(dataSlot),
+                eventContext = any()
+            )
+        } returns Unit
+
+        val provider = ConfidenceFeatureProvider.create(confidence)
+        val details = TrackingEventDetails(
+            null,
+            ImmutableStructure(
+                "context" to Value.Structure(mapOf("source" to Value.String("details")))
+            )
+        )
+
+        provider.track(
+            "Checkout",
+            ImmutableContext(attributes = mapOf("plan" to Value.String("premium"))),
+            details
+        )
+
+        assertEquals(
+            ConfidenceValue.Struct(mapOf("source" to ConfidenceValue.String("details"))),
+            dataSlot.captured["context"]
+        )
+    }
+}

--- a/Provider/src/test/java/com/spotify/confidence/openfeature/OpenFeatureTrackMapperTest.kt
+++ b/Provider/src/test/java/com/spotify/confidence/openfeature/OpenFeatureTrackMapperTest.kt
@@ -37,6 +37,18 @@ class OpenFeatureTrackMapperTest {
     }
 
     @Test
+    fun trackingDetailsLongAndFloatValuesArePreserved() {
+        val longDetails = TrackingEventDetails(499L, ImmutableStructure())
+        assertEquals(ConfidenceValue.Integer(499), longDetails.toTrackingData()["value"])
+
+        val bigLongDetails = TrackingEventDetails(10_000_000_000L, ImmutableStructure())
+        assertEquals(ConfidenceValue.Double(1.0E10), bigLongDetails.toTrackingData()["value"])
+
+        val floatDetails = TrackingEventDetails(1.5f, ImmutableStructure())
+        assertEquals(ConfidenceValue.Double(1.5), floatDetails.toTrackingData()["value"])
+    }
+
+    @Test
     fun trackContextMapIncludesTargetingKey() {
         val context = ImmutableContext(
             targetingKey = "user-1",

--- a/Provider/src/test/java/com/spotify/confidence/openfeature/OpenFeatureTrackMapperTest.kt
+++ b/Provider/src/test/java/com/spotify/confidence/openfeature/OpenFeatureTrackMapperTest.kt
@@ -1,0 +1,49 @@
+package com.spotify.confidence.openfeature
+
+import com.spotify.confidence.ConfidenceValue
+import dev.openfeature.kotlin.sdk.ImmutableContext
+import dev.openfeature.kotlin.sdk.ImmutableStructure
+import dev.openfeature.kotlin.sdk.TrackingEventDetails
+import dev.openfeature.kotlin.sdk.Value
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OpenFeatureTrackMapperTest {
+    @Test
+    fun mergeEventContextUsesOpenFeatureValuesOnConflict() {
+        val merged = mergeEventContext(
+            sessionContext = mapOf(
+                "plan" to ConfidenceValue.String("free"),
+                "visitor_id" to ConfidenceValue.String("v1")
+            ),
+            openFeatureContext = mapOf(
+                "plan" to ConfidenceValue.String("premium"),
+                "country" to ConfidenceValue.String("SE")
+            )
+        )
+        assertEquals(ConfidenceValue.String("premium"), merged["plan"])
+        assertEquals(ConfidenceValue.String("v1"), merged["visitor_id"])
+        assertEquals(ConfidenceValue.String("SE"), merged["country"])
+    }
+
+    @Test
+    fun trackingDetailsValueAttributeOverridesNumericValue() {
+        val details = TrackingEventDetails(
+            99.77,
+            ImmutableStructure("value" to Value.String("override"))
+        )
+        val data = details.toTrackingData()
+        assertEquals(ConfidenceValue.String("override"), data["value"])
+    }
+
+    @Test
+    fun trackContextMapIncludesTargetingKey() {
+        val context = ImmutableContext(
+            targetingKey = "user-1",
+            attributes = mapOf("country" to Value.String("SE"))
+        )
+        val map = context.toTrackContextMap()
+        assertEquals(ConfidenceValue.String("user-1"), map["targeting_key"])
+        assertEquals(ConfidenceValue.String("SE"), map["country"])
+    }
+}


### PR DESCRIPTION
## Summary
- Align OpenFeature `track()` with Confidence event conventions (details → data, context merge, `"value"` / `"context"` overrides).
- Improve event delivery reliability: optional interval flush, startup flush, stop/shutdown flush, provider `shutdown()` → `flush()`.

## Test plan
- [x] Provider track tests
- [x] `EventSenderEngineReliabilityTest`
- [ ] Full CI on combined branch

Supersedes #253 (reliability) — both changes are on `openfeature-track-context`.