### PR TITLE
feat: support custom resolve base URL

### DIFF
--- a/Confidence/api/Confidence.api
+++ b/Confidence/api/Confidence.api
@@ -110,7 +110,9 @@ public final class com/spotify/confidence/ConfidenceError$ParseError : java/lang
 
 public final class com/spotify/confidence/ConfidenceFactory {
 	public static final field INSTANCE Lcom/spotify/confidence/ConfidenceFactory;
+	public final fun create (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/spotify/confidence/ConfidenceRegion;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/spotify/confidence/LoggingLevel;JLjava/lang/String;)Lcom/spotify/confidence/Confidence;
 	public final fun create (Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Lcom/spotify/confidence/ConfidenceRegion;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/spotify/confidence/LoggingLevel;JLjava/lang/String;)Lcom/spotify/confidence/Confidence;
+	public static synthetic fun create$default (Lcom/spotify/confidence/ConfidenceFactory;Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/spotify/confidence/ConfidenceRegion;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/spotify/confidence/LoggingLevel;JLjava/lang/String;ILjava/lang/Object;)Lcom/spotify/confidence/Confidence;
 	public static synthetic fun create$default (Lcom/spotify/confidence/ConfidenceFactory;Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Lcom/spotify/confidence/ConfidenceRegion;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/spotify/confidence/LoggingLevel;JLjava/lang/String;ILjava/lang/Object;)Lcom/spotify/confidence/Confidence;
 }
 

--- a/Confidence/api/Confidence.api
+++ b/Confidence/api/Confidence.api
@@ -77,19 +77,6 @@ public final class com/spotify/confidence/ConfidenceError$FlagNotFoundError : ja
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/spotify/confidence/ConfidenceError$HttpError : java/lang/Error {
-	public fun <init> (ILjava/lang/String;)V
-	public final fun component1 ()I
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (ILjava/lang/String;)Lcom/spotify/confidence/ConfidenceError$HttpError;
-	public static synthetic fun copy$default (Lcom/spotify/confidence/ConfidenceError$HttpError;ILjava/lang/String;ILjava/lang/Object;)Lcom/spotify/confidence/ConfidenceError$HttpError;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getHttpCode ()I
-	public fun getMessage ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
 public final class com/spotify/confidence/ConfidenceError$InvalidContextInMessage : java/lang/Error {
 	public fun <init> ()V
 }
@@ -864,4 +851,3 @@ public final class com/spotify/confidence/serializers/ConfidenceValueSerializer 
 	public static final field INSTANCE Lcom/spotify/confidence/serializers/ConfidenceValueSerializer;
 	public synthetic fun selectDeserializer (Lkotlinx/serialization/json/JsonElement;)Lkotlinx/serialization/DeserializationStrategy;
 }
-

--- a/Confidence/api/Confidence.api
+++ b/Confidence/api/Confidence.api
@@ -851,3 +851,4 @@ public final class com/spotify/confidence/serializers/ConfidenceValueSerializer 
 	public static final field INSTANCE Lcom/spotify/confidence/serializers/ConfidenceValueSerializer;
 	public synthetic fun selectDeserializer (Lkotlinx/serialization/json/JsonElement;)Lkotlinx/serialization/DeserializationStrategy;
 }
+

--- a/Confidence/api/Confidence.api
+++ b/Confidence/api/Confidence.api
@@ -77,6 +77,19 @@ public final class com/spotify/confidence/ConfidenceError$FlagNotFoundError : ja
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/spotify/confidence/ConfidenceError$HttpError : java/lang/Error {
+	public fun <init> (ILjava/lang/String;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (ILjava/lang/String;)Lcom/spotify/confidence/ConfidenceError$HttpError;
+	public static synthetic fun copy$default (Lcom/spotify/confidence/ConfidenceError$HttpError;ILjava/lang/String;ILjava/lang/Object;)Lcom/spotify/confidence/ConfidenceError$HttpError;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHttpCode ()I
+	public fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/spotify/confidence/ConfidenceError$InvalidContextInMessage : java/lang/Error {
 	public fun <init> ()V
 }

--- a/Confidence/src/main/java/com/spotify/confidence/Confidence.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/Confidence.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.yield
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
 
@@ -386,6 +387,55 @@ object ConfidenceFactory {
         loggingLevel: LoggingLevel = LoggingLevel.WARN,
         timeoutMillis: Long = 10000,
         visitorIdContextKey: String = VISITOR_ID_CONTEXT_KEY
+    ): Confidence = create(
+        context = context,
+        clientSecret = clientSecret,
+        initialContext = initialContext,
+        region = region,
+        dispatcher = dispatcher,
+        loggingLevel = loggingLevel,
+        timeoutMillis = timeoutMillis,
+        visitorIdContextKey = visitorIdContextKey,
+        resolveBaseUrl = null
+    )
+
+    /**
+     * Create a Factory Confidence instance using a custom base URL for resolve and apply requests.
+     * The SDK appends `/v1/flags:resolve` and `/v1/flags:apply` to [resolveBaseUrl].
+     * Event tracking continues to use the Confidence events endpoint.
+     */
+    fun create(
+        context: Context,
+        clientSecret: String,
+        resolveBaseUrl: String,
+        initialContext: Map<String, ConfidenceValue> = mapOf(),
+        region: ConfidenceRegion = ConfidenceRegion.GLOBAL,
+        dispatcher: CoroutineDispatcher = Dispatchers.IO,
+        loggingLevel: LoggingLevel = LoggingLevel.WARN,
+        timeoutMillis: Long = 10000,
+        visitorIdContextKey: String = VISITOR_ID_CONTEXT_KEY
+    ): Confidence = create(
+        context = context,
+        clientSecret = clientSecret,
+        initialContext = initialContext,
+        region = region,
+        dispatcher = dispatcher,
+        loggingLevel = loggingLevel,
+        timeoutMillis = timeoutMillis,
+        visitorIdContextKey = visitorIdContextKey,
+        resolveBaseUrl = getResolveBaseUrl(region, resolveBaseUrl)
+    )
+
+    private fun create(
+        context: Context,
+        clientSecret: String,
+        initialContext: Map<String, ConfidenceValue>,
+        region: ConfidenceRegion,
+        dispatcher: CoroutineDispatcher,
+        loggingLevel: LoggingLevel,
+        timeoutMillis: Long,
+        visitorIdContextKey: String,
+        resolveBaseUrl: HttpUrl?
     ): Confidence {
         val debugLogger: DebugLogger? = if (loggingLevel == LoggingLevel.NONE) {
             null
@@ -406,7 +456,8 @@ object ConfidenceFactory {
             clientSecret,
             telemetry,
             region,
-            dispatcher
+            dispatcher,
+            resolveBaseUrl
         )
         val flagResolver = RemoteFlagResolver(
             clientSecret = clientSecret,
@@ -417,6 +468,7 @@ object ConfidenceFactory {
                 .build(),
             dispatcher = dispatcher,
             telemetry = telemetry,
+            baseUrl = resolveBaseUrl,
             debugLogger = debugLogger
         )
 

--- a/Confidence/src/main/java/com/spotify/confidence/RemoteFlagResolver.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/RemoteFlagResolver.kt
@@ -48,7 +48,7 @@ internal class RemoteFlagResolver(
         val response = withContext(dispatcher) {
             val jsonRequest = Json.encodeToString(request)
             val requestBuilder = Request.Builder()
-                .url(resolveBaseUrl.resolveEndpoint("resolve"))
+                .url(resolveBaseUrl.resolveEndpoint())
                 .headers(headers)
                 .post(jsonRequest.toRequestBody())
 

--- a/Confidence/src/main/java/com/spotify/confidence/RemoteFlagResolver.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/RemoteFlagResolver.kt
@@ -34,6 +34,7 @@ internal class RemoteFlagResolver(
     private val baseUrl: HttpUrl? = null,
     private val debugLogger: DebugLogger? = null
 ) : FlagResolver {
+    private val resolveBaseUrl = baseUrl ?: getResolveBaseUrl(region)
     private val headers = Headers.headersOf(
         "Content-Type",
         "application/json",
@@ -47,7 +48,7 @@ internal class RemoteFlagResolver(
         val response = withContext(dispatcher) {
             val jsonRequest = Json.encodeToString(request)
             val requestBuilder = Request.Builder()
-                .url("${baseUrl()}/v1/flags:resolve")
+                .url(resolveBaseUrl.resolveEndpoint("resolve"))
                 .headers(headers)
                 .post(jsonRequest.toRequestBody())
 
@@ -97,12 +98,6 @@ internal class RemoteFlagResolver(
                 Result.Success(FlagResolution.EMPTY)
             }
         }
-    }
-
-    private fun baseUrl() = baseUrl ?: when (region) {
-        ConfidenceRegion.GLOBAL -> "https://resolver.confidence.dev"
-        ConfidenceRegion.EUROPE -> "https://resolver.eu.confidence.dev"
-        ConfidenceRegion.USA -> "https://resolver.us.confidence.dev"
     }
 
     private fun Response.toResolveFlags(): ResolveResponse {

--- a/Confidence/src/main/java/com/spotify/confidence/ResolveBaseUrl.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/ResolveBaseUrl.kt
@@ -15,7 +15,11 @@ internal fun getResolveBaseUrl(
     return baseUrl.trimEnd('/').toHttpUrl()
 }
 
-internal fun HttpUrl.resolveEndpoint(operation: String): HttpUrl =
+internal fun HttpUrl.resolveEndpoint(): HttpUrl = flagEndpoint("resolve")
+
+internal fun HttpUrl.applyEndpoint(): HttpUrl = flagEndpoint("apply")
+
+private fun HttpUrl.flagEndpoint(operation: String): HttpUrl =
     newBuilder()
         .addPathSegments("v1/flags:$operation")
         .build()

--- a/Confidence/src/main/java/com/spotify/confidence/ResolveBaseUrl.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/ResolveBaseUrl.kt
@@ -1,0 +1,21 @@
+package com.spotify.confidence
+
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+
+internal fun getResolveBaseUrl(
+    region: ConfidenceRegion,
+    resolveBaseUrl: String? = null
+): HttpUrl {
+    val baseUrl = resolveBaseUrl ?: when (region) {
+        ConfidenceRegion.GLOBAL -> "https://resolver.confidence.dev"
+        ConfidenceRegion.EUROPE -> "https://resolver.eu.confidence.dev"
+        ConfidenceRegion.USA -> "https://resolver.us.confidence.dev"
+    }
+    return baseUrl.trimEnd('/').toHttpUrl()
+}
+
+internal fun HttpUrl.resolveEndpoint(operation: String): HttpUrl =
+    newBuilder()
+        .addPathSegments("v1/flags:$operation")
+        .build()

--- a/Confidence/src/main/java/com/spotify/confidence/client/FlagApplierClientImpl.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/client/FlagApplierClientImpl.kt
@@ -6,6 +6,7 @@ import com.spotify.confidence.Telemetry
 import com.spotify.confidence.client.network.ApplyFlagsInteractor
 import com.spotify.confidence.client.network.ApplyFlagsInteractorImpl
 import com.spotify.confidence.client.network.ApplyFlagsRequest
+import com.spotify.confidence.getResolveBaseUrl
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import okhttp3.Headers
@@ -16,7 +17,7 @@ internal class FlagApplierClientImpl : FlagApplierClient {
     private val clientSecret: String
     private val telemetry: Telemetry
     private val okHttpClient: OkHttpClient
-    private val baseUrl: String
+    private val baseUrl: HttpUrl
     private val headers: Headers
     private val clock: Clock
     private val dispatcher: CoroutineDispatcher
@@ -26,7 +27,8 @@ internal class FlagApplierClientImpl : FlagApplierClient {
         clientSecret: String,
         telemetry: Telemetry,
         region: ConfidenceRegion,
-        dispatcher: CoroutineDispatcher = Dispatchers.IO
+        dispatcher: CoroutineDispatcher = Dispatchers.IO,
+        resolveBaseUrl: HttpUrl? = null
     ) {
         this.clientSecret = clientSecret
         this.telemetry = telemetry
@@ -37,11 +39,7 @@ internal class FlagApplierClientImpl : FlagApplierClient {
             "Accept",
             "application/json"
         )
-        baseUrl = when (region) {
-            ConfidenceRegion.GLOBAL -> "https://resolver.confidence.dev"
-            ConfidenceRegion.EUROPE -> "https://resolver.eu.confidence.dev"
-            ConfidenceRegion.USA -> "https://resolver.us.confidence.dev"
-        }
+        baseUrl = getResolveBaseUrl(region, resolveBaseUrl?.toString())
         this.clock = Clock.CalendarBacked.systemUTC()
         this.dispatcher = dispatcher
 
@@ -68,13 +66,13 @@ internal class FlagApplierClientImpl : FlagApplierClient {
             "Accept",
             "application/json"
         )
-        this.baseUrl = baseUrl.toString()
+        this.baseUrl = baseUrl
         this.clock = clock
         this.dispatcher = dispatcher
 
         this.applyInteractor = ApplyFlagsInteractorImpl(
             httpClient = okHttpClient,
-            baseUrl = baseUrl.toString(),
+            baseUrl = baseUrl,
             dispatcher = dispatcher
         )
     }

--- a/Confidence/src/main/java/com/spotify/confidence/client/network/ApplyFlagsInteractor.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/client/network/ApplyFlagsInteractor.kt
@@ -3,12 +3,14 @@ package com.spotify.confidence.client.network
 import com.spotify.confidence.client.AppliedFlag
 import com.spotify.confidence.client.Sdk
 import com.spotify.confidence.client.await
+import com.spotify.confidence.resolveEndpoint
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okhttp3.Headers
+import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -21,7 +23,7 @@ internal interface ApplyFlagsInteractor {
 
 internal class ApplyFlagsInteractorImpl(
     private val httpClient: OkHttpClient,
-    private val baseUrl: String,
+    private val baseUrl: HttpUrl,
     private val dispatcher: CoroutineDispatcher
 ) : ApplyFlagsInteractor {
 
@@ -36,7 +38,7 @@ internal class ApplyFlagsInteractorImpl(
     override suspend fun invoke(request: ApplyFlagsRequest, extraHeaders: Map<String, String>): Response =
         withContext(dispatcher) {
             val requestBuilder = Request.Builder()
-                .url("$baseUrl/v1/flags:apply")
+                .url(baseUrl.resolveEndpoint("apply"))
                 .headers(headers)
                 .post(Json.encodeToString(request).toRequestBody())
 

--- a/Confidence/src/main/java/com/spotify/confidence/client/network/ApplyFlagsInteractor.kt
+++ b/Confidence/src/main/java/com/spotify/confidence/client/network/ApplyFlagsInteractor.kt
@@ -1,9 +1,9 @@
 package com.spotify.confidence.client.network
 
+import com.spotify.confidence.applyEndpoint
 import com.spotify.confidence.client.AppliedFlag
 import com.spotify.confidence.client.Sdk
 import com.spotify.confidence.client.await
-import com.spotify.confidence.resolveEndpoint
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
@@ -38,7 +38,7 @@ internal class ApplyFlagsInteractorImpl(
     override suspend fun invoke(request: ApplyFlagsRequest, extraHeaders: Map<String, String>): Response =
         withContext(dispatcher) {
             val requestBuilder = Request.Builder()
-                .url(baseUrl.resolveEndpoint("apply"))
+                .url(baseUrl.applyEndpoint())
                 .headers(headers)
                 .post(Json.encodeToString(request).toRequestBody())
 

--- a/Confidence/src/test/java/com/spotify/confidence/ResolveBaseUrlTest.kt
+++ b/Confidence/src/test/java/com/spotify/confidence/ResolveBaseUrlTest.kt
@@ -1,0 +1,108 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.spotify.confidence
+
+import android.content.Context
+import com.spotify.confidence.client.AppliedFlag
+import com.spotify.confidence.client.FlagApplierClientImpl
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.nio.file.Files
+import java.time.Instant
+import java.util.Date
+
+class ResolveBaseUrlTest {
+    private val mockWebServer = MockWebServer()
+    private val mockContext: Context = mock()
+
+    @Before
+    fun setUp() {
+        mockWebServer.start()
+        whenever(mockContext.filesDir).thenReturn(Files.createTempDirectory("flags").toFile())
+        whenever(mockContext.getDir(any(), any())).thenReturn(Files.createTempDirectory("events").toFile())
+        whenever(mockContext.getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE))
+            .thenReturn(InMemorySharedPreferences())
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun customResolveBaseUrlIsNormalizedWithoutTrailingSlash() {
+        assertEquals(
+            mockWebServer.url(""),
+            getResolveBaseUrl(ConfidenceRegion.USA, "${mockWebServer.url("")}/")
+        )
+    }
+
+    @Test
+    fun customResolveBaseUrlWithoutTrailingSlashIsUsedAsIs() {
+        assertEquals(
+            mockWebServer.url(""),
+            getResolveBaseUrl(
+                ConfidenceRegion.USA,
+                mockWebServer.url("").toString().trimEnd('/')
+            )
+        )
+    }
+
+    @Test
+    fun resolverUsesCustomResolveBaseUrl() = runTest {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"resolvedFlags": [], "resolveToken": "token"}""")
+        )
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val confidence = ConfidenceFactory.create(
+            context = mockContext,
+            clientSecret = "secret",
+            dispatcher = dispatcher,
+            resolveBaseUrl = "${mockWebServer.url("")}/"
+        )
+
+        confidence.fetchAndActivate()
+
+        assertEquals("/v1/flags:resolve", mockWebServer.takeRequest().path)
+        confidence.stop()
+    }
+
+    @Test
+    fun applierUsesCustomResolveBaseUrl() = runTest {
+        mockWebServer.enqueue(MockResponse().setResponseCode(200))
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val client = FlagApplierClientImpl(
+            clientSecret = "secret",
+            telemetry = Telemetry("test", Telemetry.Library.CONFIDENCE, "test"),
+            region = ConfidenceRegion.USA,
+            dispatcher = dispatcher,
+            resolveBaseUrl = mockWebServer.url("")
+        )
+
+        client.apply(
+            listOf(AppliedFlag("flag", Date.from(Instant.parse("2026-08-18T11:00:00Z")))),
+            "token"
+        )
+
+        assertEquals("/v1/flags:apply", mockWebServer.takeRequest().path)
+    }
+
+    @Test
+    fun regionalResolveBaseUrlIsUsedByDefault() {
+        assertEquals(
+            "https://resolver.us.confidence.dev/",
+            getResolveBaseUrl(ConfidenceRegion.USA).toString()
+        )
+    }
+}

--- a/README.md
+++ b/README.md
@@ -56,13 +56,11 @@ Configure a custom resolve base URL to send flag resolve and apply requests to a
 val confidence = ConfidenceFactory.create(
     context = app.applicationContext,
     clientSecret = "<MY_SECRET>",
-    resolveBaseUrl = "http://10.0.2.2:8090"
+    resolveBaseUrl = "<my-custom-url>"
 )
 ```
 
 The SDK appends `/v1/flags:resolve` and `/v1/flags:apply` to this URL. Event tracking is not supported by the sidecar resolver and continues to use `https://events.confidence.dev/v1/events:publish`.
-
-`10.0.2.2` connects an Android emulator to a resolver running on the development machine. Local plain HTTP connections may also require an [Android network security configuration](https://developer.android.com/privacy-and-security/security-config) that permits cleartext traffic.
 
 #### Initialization strategy
 `initialisationStrategy` is a way to decide how Confidence should act when the provider is being set.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ OpenFeatureAPI.setProviderAndWait(provider)
 Where `MY_SECRET` is an API key that can be generated in the [Confidence UI](https://confidence.spotify.com/console).
 The `loggingLevel` sets the verbosity level for logging to console. This can be useful while testing your integration with the Confidence SDK.
 
+#### Using a self-hosted local resolver SDK or sidecar resolver
+
+Configure a custom resolve base URL to send flag resolve and apply requests to a [Confidence local resolver](https://confidence.spotify.com/docs/flags/local-resolver) or self-hosted sidecar resolver:
+
+```kotlin
+val confidence = ConfidenceFactory.create(
+    context = app.applicationContext,
+    clientSecret = "<MY_SECRET>",
+    resolveBaseUrl = "http://10.0.2.2:8090"
+)
+```
+
+The SDK appends `/v1/flags:resolve` and `/v1/flags:apply` to this URL. Event tracking is not supported by the sidecar resolver and continues to use `https://events.confidence.dev/v1/events:publish`.
+
+`10.0.2.2` connects an Android emulator to a resolver running on the development machine. Local plain HTTP connections may also require an [Android network security configuration](https://developer.android.com/privacy-and-security/security-config) that permits cleartext traffic.
+
 #### Initialization strategy
 `initialisationStrategy` is a way to decide how Confidence should act when the provider is being set.
 - `ActivateAndFetchAsync` will make the last fetched flags available immediately and then trigger a background fetch to update the flags for future sessions.


### PR DESCRIPTION
## Summary
- add a resolveBaseUrl factory option for resolve and apply requests
- preserve regional defaults and keep event tracking on the Confidence events endpoint
- document sidecar setup

## Testing
- focused resolve base URL tests
- existing remote client tests
- assembleDebug
- ktlintCheck